### PR TITLE
fix: SENDGRID_TOKEN value in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,5 +7,5 @@ DB_USER=unics_social
 DB_PASSWORD=password123
 DB_DATABASE=unics_social
 
-SENDGRID_TOKEN=abc123
+SENDGRID_TOKEN=SG.abc123
 JWT_SECRET=thisisasecret


### PR DESCRIPTION
Changed from abc123 to SG.abc123