### PR TITLE
feat: add SENDGRID_FROM_EMAIL env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,4 +8,5 @@ DB_PASSWORD=password123
 DB_DATABASE=unics_social
 
 SENDGRID_TOKEN=SG.abc123
+SENDGRID_FROM_EMAIL=noreply@unicsmcr.com
 JWT_SECRET=thisisasecret

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ test: export DB_USER=unics_social
 test: export DB_PASSWORD=password123
 test: export DB_DATABASE=unics_social
 test: export SENDGRID_TOKEN=SG.abc123
+test: export SENDGRID_FROM_EMAIL=noreply@unicsmcr.com
 test: export JWT_SECRET=thisisasecret
 test:
 	docker-compose -f tests/docker-compose.yml up -d db

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ An API Server for UniCS's networking platform for its members at the University 
 	$ npm install
 	```
 - You now need to create an `.env` file - this is a configuration file for the project. You can just copy the included `.env.example` to create yours. I would not recommend changing most values unless they cause problems.
-	> To get the email service working, you'll need to [create a SendGrid API key](https://sendgrid.com/) and go through [Single Sender Verification](https://sendgrid.com/docs/ui/sending-email/sender-verification/) to an email you have access to. You then need to set this email address and the SendGrid token in the `.env` file (`SENDGRID_FROM_EMAIL` and `SENDGRID_TOKEN` respectively).
+	> To get the email service working, you'll need to [create a SendGrid API key](https://sendgrid.com/) and go through [Single Sender Verification](https://sendgrid.com/docs/ui/sending-email/sender-verification/) to an email you have access to. You then need to set this email address and the SendGrid token in the `.env` file (`SENDGRID_FROM_EMAIL` and `SENDGRID_TOKEN` respectively.)
 	> 
-	> This is due to security reasons on SendGrid's side which disallow you from using `noreply@unicsmcr.com` as you cannot prove you have access to that email, so the service is unable to send email as if it is from that address. This is why you have to use a personal email address you have access to.
+	> This is due to security reasons on SendGrid's side which disallow you from using `noreply@unicsmcr.com` as you cannot prove you have access to that email, so the service is unable to send email as if it is from that address. This is why you have to use a personal email address that you have access to.
 - Launch the PostgreSQL database and its admin tool:
 	```
 	$ docker-compose up -d

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ An API Server for UniCS's networking platform for its members at the University 
 	$ npm install
 	```
 - You now need to create an `.env` file - this is a configuration file for the project. You can just copy the included `.env.example` to create yours. I would not recommend changing most values unless they cause problems.
-	> To get the email service working, you'll need to [create a SendGrid API key](https://sendgrid.com/) and go through [Single Sender Verification](https://sendgrid.com/docs/ui/sending-email/sender-verification/) to an email you have access to. You then need to set this email address and the SendGrid token in the `.env` file (`SENDGRID_FROM_EMAIL` and `SENDGRID_TOKEN` respectively.)
+	> To get the email service working, you'll need to [create a SendGrid API key](https://sendgrid.com/) and go through [Single Sender Verification](https://sendgrid.com/docs/ui/sending-email/sender-verification/) for an email you have access to. You then need to set this email address and the SendGrid API key in the `.env` file (`SENDGRID_FROM_EMAIL` and `SENDGRID_TOKEN` respectively.)
 	> 
 	> This is due to security reasons on SendGrid's side which disallow you from using `noreply@unicsmcr.com` as you cannot prove you have access to that email, so the service is unable to send email as if it is from that address. This is why you have to use a personal email address that you have access to.
 - Launch the PostgreSQL database and its admin tool:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ An API Server for UniCS's networking platform for its members at the University 
 
 	$ npm install
 	```
-- You now need to create an `.env` file - this is a configuration file for the project. You can just copy the included `.env.example` to create yours. I would not recommend changing it unless the existing values cause problems.
+- You now need to create an `.env` file - this is a configuration file for the project. You can just copy the included `.env.example` to create yours. I would not recommend changing most values unless they cause problems.
+	> To get the email service working, you'll need to [create a SendGrid API key](https://sendgrid.com/) and go through [Single Sender Verification](https://sendgrid.com/docs/ui/sending-email/sender-verification/) to an email you have access to. You then need to set this email address and the SendGrid token in the `.env` file (`SENDGRID_FROM_EMAIL` and `SENDGRID_TOKEN` respectively).
+	> 
+	> This is due to security reasons on SendGrid's side which disallow you from using `noreply@unicsmcr.com` as you cannot prove you have access to that email, so the service is unable to send email as if it is from that address. This is why you have to use a personal email address you have access to.
 - Launch the PostgreSQL database and its admin tool:
 	```
 	$ docker-compose up -d

--- a/src/services/EmailService.ts
+++ b/src/services/EmailService.ts
@@ -5,13 +5,13 @@ import { getConfig } from '../util/config';
 @injectable()
 export default class EmailService {
 	public constructor() {
-		setApiKey(getConfig().sendgridToken);
+		setApiKey(getConfig().sendgrid.token);
 	}
 
 	public sendEmail(data: { to: string; html: string; subject: string }) {
-		setApiKey(getConfig().sendgridToken);
+		setApiKey(getConfig().sendgrid.token);
 		return send({
-			from: 'noreply@unicsmcr.com',
+			from: getConfig().sendgrid.fromEmail,
 			...data
 		});
 	}

--- a/src/util/config/index.ts
+++ b/src/util/config/index.ts
@@ -8,7 +8,6 @@ export enum Environment {
 export interface EnvConfig {
 	port: number;
 	logErrors: boolean;
-	sendgridToken: string;
 	jwtSecret: string;
 	db: {
 		host: string;
@@ -17,13 +16,16 @@ export interface EnvConfig {
 		password: string;
 		database: string;
 	};
+	sendgrid: {
+		fromEmail: string;
+		token: string;
+	};
 }
 
 export function load(source: Record<string, string | undefined> = process.env): EnvConfig {
 	return {
 		port: intoNumber(getEnv(source, 'PORT')),
 		logErrors: intoBoolean(getEnv(source, 'LOG_ERRORS')),
-		sendgridToken: getEnv(source, 'SENDGRID_TOKEN'),
 		jwtSecret: getEnv(source, 'JWT_SECRET'),
 		db: {
 			host: getEnv(source, 'DB_HOST'),
@@ -31,6 +33,10 @@ export function load(source: Record<string, string | undefined> = process.env): 
 			username: getEnv(source, 'DB_USER'),
 			password: getEnv(source, 'DB_PASSWORD'),
 			database: getEnv(source, 'DB_DATABASE')
+		},
+		sendgrid: {
+			fromEmail: getEnv(source, 'SENDGRID_FROM_EMAIL'),
+			token: getEnv(source, 'SENDGRID_TOKEN')
 		}
 	};
 }
@@ -45,4 +51,3 @@ export function getConfig(source?: Record<string, string | undefined>, refresh =
 	}
 	return globalConfig;
 }
-

--- a/tests/integration/services/emailService.test.ts
+++ b/tests/integration/services/emailService.test.ts
@@ -2,6 +2,7 @@ import 'reflect-metadata';
 
 import sendgrid from '@sendgrid/mail';
 import EmailService from '../../../src/services/EmailService';
+import { getConfig } from '../../../src/util/config';
 
 const mockedSend = jest.spyOn(sendgrid, 'send');
 
@@ -21,7 +22,7 @@ describe('EmailService', () => {
 
 		const emailService = new EmailService();
 		await emailService.sendEmail(fixture);
-		expect(mockedSend).toHaveBeenCalledWith({ ...fixture, from: 'noreply@unicsmcr.com' });
+		expect(mockedSend).toHaveBeenCalledWith({ ...fixture, from: getConfig().sendgrid.fromEmail });
 	});
 
 	test('Fails when send fails', async () => {
@@ -35,6 +36,6 @@ describe('EmailService', () => {
 
 		const emailService = new EmailService();
 		await expect(emailService.sendEmail(fixture)).rejects.toThrow();
-		expect(mockedSend).toHaveBeenCalledWith({ ...fixture, from: 'noreply@unicsmcr.com' });
+		expect(mockedSend).toHaveBeenCalledWith({ ...fixture, from: getConfig().sendgrid.fromEmail });
 	});
 });

--- a/tests/unit/util/config/config.test.ts
+++ b/tests/unit/util/config/config.test.ts
@@ -12,6 +12,7 @@ const fixture1: [Record<string, string>, EnvConfig] = [
 		DB_PASSWORD: 'password',
 		DB_DATABASE: 'unics_social',
 		SENDGRID_TOKEN: 'abc123',
+		SENDGRID_FROM_EMAIL: 'noreply@unicsmcr.com',
 		JWT_SECRET: 'test123test'
 	},
 	{
@@ -24,7 +25,10 @@ const fixture1: [Record<string, string>, EnvConfig] = [
 			password: 'password',
 			database: 'unics_social'
 		},
-		sendgridToken: 'abc123',
+		sendgrid: {
+			token: 'abc123',
+			fromEmail: 'noreply@unicsmcr.com'
+		},
 		jwtSecret: 'test123test'
 	}
 ];
@@ -40,6 +44,7 @@ const fixture2: [Record<string, string>, EnvConfig] = [
 		DB_PASSWORD: 'password',
 		DB_DATABASE: 'unics_social',
 		SENDGRID_TOKEN: 'token!!!',
+		SENDGRID_FROM_EMAIL: 'test@gmail.com',
 		JWT_SECRET: 'asecret'
 	},
 	{
@@ -52,7 +57,10 @@ const fixture2: [Record<string, string>, EnvConfig] = [
 			password: 'password',
 			database: 'unics_social'
 		},
-		sendgridToken: 'token!!!',
+		sendgrid: {
+			token: 'token!!!',
+			fromEmail: 'test@gmail.com'
+		},
 		jwtSecret: 'asecret'
 	}
 ];


### PR DESCRIPTION
It appears that on new SendGrid accounts, you need to verify the account you're sending email from for requests to succeed. This PR allows people to go through this process and then set the email they've used in the `SENDGRID_FROM_EMAIL` env variable to get the email service working.