### PR TITLE
feat: implement basic gateway

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1149,6 +1149,14 @@
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.0.0.tgz",
       "integrity": "sha512-WAy5txG7aFX8Vw3sloEKp5p/t/Xt8jD3GRD9DacnFv6Vo8ubudAsRTXgxpQwU0mpzY/H8U4db3roDuCMjShBmw=="
     },
+    "@types/ws": {
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.6.tgz",
+      "integrity": "sha512-Q07IrQUSNpr+cXU4E4LtkSIBPie5GLZyyMC1QtQYRLWz701+XcoVygGUZgvLqElq1nU4ICldMYPnexlBsg3dqQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/yargs": {
       "version": "15.0.5",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
@@ -7313,8 +7321,7 @@
     "ws": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
-      "dev": true
+      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   "@sendgrid/mail": "^7.2.1",
   "@types/express": "^4.17.7",
   "@types/jsonwebtoken": "^8.5.0",
+  "@types/ws": "^7.2.6",
   "class-validator": "^0.12.2",
   "dotenv": "^8.2.0",
   "express": "^4.17.1",
@@ -80,6 +81,7 @@
   "pg": "^8.3.0",
   "reflect-metadata": "^0.1.13",
   "tsyringe": "^4.3.0",
-  "typeorm": "^0.2.25"
+  "typeorm": "^0.2.25",
+  "ws": "^7.3.1"
  }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,10 +1,19 @@
 import { createApp } from '.';
 import { getConfig } from './util/config';
+import { createServer } from 'http';
+import { Server as WebSocketServer } from 'ws';
 
 createApp()
 	.then(app => {
 		const port = getConfig().port;
-		app.listen(port, () => {
+		const server = createServer(app);
+
+		const wss = new WebSocketServer({ server, path: '/api/v1/gateway' });
+		wss.on('connection', ws => {
+			ws.send(JSON.stringify({ message: 'hi' }));
+		});
+
+		server.listen(port, () => {
 			console.log(`Listening on port ${port}`);
 		});
 	})

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-import { createApp } from '.';
+import { createApp, createGateway } from '.';
 import { getConfig } from './util/config';
 import { createServer } from 'http';
 import { Server as WebSocketServer } from 'ws';
@@ -9,9 +9,7 @@ createApp()
 		const server = createServer(app);
 
 		const wss = new WebSocketServer({ server, path: '/api/v1/gateway' });
-		wss.on('connection', ws => {
-			ws.send(JSON.stringify({ message: 'hi' }));
-		});
+		createGateway(wss);
 
 		server.listen(port, () => {
 			console.log(`Listening on port ${port}`);

--- a/src/controllers/GatewayController.ts
+++ b/src/controllers/GatewayController.ts
@@ -48,8 +48,7 @@ export default class GatewayController {
 	private async onPacket(ws: WebSocket, packet: GatewayPacket) {
 		switch (packet.t) {
 			case GatewayPacketType.Identify:
-				await this.onAuthenticate(ws, packet as IdentifyGatewayPacket);
-				break;
+				return this.onAuthenticate(ws, packet as IdentifyGatewayPacket);
 			default:
 				throw new GatewayError(`Received invalid packet type ${packet.t}`);
 		}
@@ -66,6 +65,5 @@ export default class GatewayController {
 		await this.gatewayService.send([ws], {
 			t: GatewayPacketType.Hello
 		} as HelloGatewayPacket);
-		return user;
 	}
 }

--- a/src/controllers/GatewayController.ts
+++ b/src/controllers/GatewayController.ts
@@ -1,0 +1,32 @@
+import { inject, singleton } from 'tsyringe';
+import GatewayService from '../services/GatewayService';
+import WebSocket, { Server as WebSocketServer, Data as WebSocketData } from 'ws';
+import { User } from '../entities/User';
+
+@singleton()
+export default class GatewayController {
+	private readonly gatewayService: GatewayService;
+	private wss?: WebSocketServer;
+	private readonly authenticatedClients: Map<WebSocket, User>;
+
+	public constructor(@inject(GatewayService) gatewayService: GatewayService) {
+		this.authenticatedClients = new Map();
+		this.gatewayService = gatewayService;
+	}
+
+	public bindTo(wss: WebSocketServer) {
+		if (this.wss) throw new Error('WebSocketServer is already bound!');
+		this.wss = wss;
+		this.wss.on('connection', ws => {
+			ws.on('message', data => this.onMessage(ws, data));
+			ws.on('close', (code, reason) => {
+				this.authenticatedClients.delete(ws);
+				console.log(code, reason);
+			});
+		});
+	}
+
+	private onMessage(ws: WebSocket, data: WebSocketData) {
+		console.log(data);
+	}
+}

--- a/src/controllers/GatewayController.ts
+++ b/src/controllers/GatewayController.ts
@@ -1,24 +1,31 @@
 import { inject, singleton } from 'tsyringe';
-import GatewayService from '../services/GatewayService';
-import WebSocket, { Server as WebSocketServer, Data as WebSocketData } from 'ws';
+import GatewayService, { GatewayPacket, GatewayPacketType, AuthenticateGatewayPacket, HelloGatewayPacket } from '../services/GatewayService';
+import WebSocket, { Server as WebSocketServer, Data } from 'ws';
 import { User } from '../entities/User';
+import { UserService } from '../services/UserService';
+import { verifyJWT } from '../util/auth';
 
 @singleton()
 export default class GatewayController {
 	private readonly gatewayService: GatewayService;
+	private readonly userService: UserService;
 	private wss?: WebSocketServer;
-	private readonly authenticatedClients: Map<WebSocket, User>;
+	public readonly authenticatedClients: Map<WebSocket, User>;
 
-	public constructor(@inject(GatewayService) gatewayService: GatewayService) {
+	public constructor(@inject(GatewayService) gatewayService: GatewayService, @inject(UserService) userService: UserService) {
 		this.authenticatedClients = new Map();
 		this.gatewayService = gatewayService;
+		this.userService = userService;
 	}
 
 	public bindTo(wss: WebSocketServer) {
 		if (this.wss) throw new Error('WebSocketServer is already bound!');
 		this.wss = wss;
 		this.wss.on('connection', ws => {
-			ws.on('message', data => this.onMessage(ws, data));
+			ws.on('message', data => void this.onMessage(ws, data).catch(error => {
+				console.error(error);
+				ws.close();
+			}));
 			ws.on('close', (code, reason) => {
 				this.authenticatedClients.delete(ws);
 				console.log(code, reason);
@@ -26,7 +33,31 @@ export default class GatewayController {
 		});
 	}
 
-	private onMessage(ws: WebSocket, data: WebSocketData) {
-		console.log(data);
+	private onMessage(ws: WebSocket, data: Data) {
+		const packet = this.gatewayService.parseIncoming(data);
+		return this.onPacket(ws, packet);
+	}
+
+	private async onPacket(ws: WebSocket, packet: GatewayPacket) {
+		if (packet.t === GatewayPacketType.Authenticate) {
+			await this.onAuthenticate(ws, packet as AuthenticateGatewayPacket);
+		}
+	}
+
+	public async onAuthenticate(ws: WebSocket, packet: AuthenticateGatewayPacket) {
+		let user = this.authenticatedClients.get(ws);
+		if (user) throw new Error('Already authenticated!');
+		const { token } = packet.d;
+		const { id } = await verifyJWT(token);
+		user = await this.userService.findOne({ id });
+		if (!user) throw new Error('User not found');
+		this.authenticatedClients.set(ws, user);
+		await this.gatewayService.send([ws], {
+			t: GatewayPacketType.Hello,
+			d: {
+				time: new Date().toISOString()
+			}
+		} as HelloGatewayPacket);
+		return user;
 	}
 }

--- a/src/controllers/GatewayController.ts
+++ b/src/controllers/GatewayController.ts
@@ -46,24 +46,24 @@ export default class GatewayController {
 	}
 
 	private async onPacket(ws: WebSocket, packet: GatewayPacket) {
-		switch (packet.t) {
+		switch (packet.type) {
 			case GatewayPacketType.Identify:
 				return this.onAuthenticate(ws, packet as IdentifyGatewayPacket);
 			default:
-				throw new GatewayError(`Received invalid packet type ${packet.t}`);
+				throw new GatewayError(`Received invalid packet type ${packet.type}`);
 		}
 	}
 
 	public async onAuthenticate(ws: WebSocket, packet: IdentifyGatewayPacket) {
 		let user = this.authenticatedClients.get(ws);
 		if (user) throw new GatewayError('Already authenticated!');
-		const { token } = packet.d;
+		const { token } = packet.data;
 		const { id } = await verifyJWT(token).catch(() => Promise.reject(new GatewayError('Invalid token')));
 		user = await this.userService.findOne({ id });
 		if (!user) throw new GatewayError('User not found');
 		this.authenticatedClients.set(ws, user);
 		await this.gatewayService.send([ws], {
-			t: GatewayPacketType.Hello
+			type: GatewayPacketType.Hello
 		} as HelloGatewayPacket);
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,8 @@ import Profile from './entities/Profile';
 import EmailService from './services/email/EmailService';
 import MockEmailService from './services/email/MockEmailService';
 import { APIError } from './util/errors';
+import { Server as WebSocketServer } from 'ws';
+import GatewayController from './controllers/GatewayController';
 
 export function createExpress() {
 	const app = express();
@@ -70,4 +72,10 @@ export async function createApp() {
 	const app = createExpress();
 	await createDBConnection();
 	return app;
+}
+
+export function createGateway(wss: WebSocketServer) {
+	const gatewayController = container.resolve(GatewayController);
+	gatewayController.bindTo(wss);
+	return gatewayController;
 }

--- a/src/services/GatewayService.ts
+++ b/src/services/GatewayService.ts
@@ -11,7 +11,11 @@ export default class GatewayService {
 		if (typeof data !== 'string') {
 			throw new GatewayError('Invalid incoming message type');
 		}
-		return JSON.parse(data);
+		try {
+			return JSON.parse(data);
+		} catch (error) {
+			throw new GatewayError('Invalid packet');
+		}
 	}
 
 	private sendData(client: WebSocket, data: string): Promise<void> {

--- a/src/services/GatewayService.ts
+++ b/src/services/GatewayService.ts
@@ -1,0 +1,11 @@
+import { injectable, inject } from 'tsyringe';
+import { UserService } from './UserService';
+
+@injectable()
+export default class GatewayService {
+	private readonly userService: UserService;
+
+	public constructor(@inject(UserService) userService: UserService) {
+		this.userService = userService;
+	}
+}

--- a/src/services/GatewayService.ts
+++ b/src/services/GatewayService.ts
@@ -7,9 +7,10 @@ export default class GatewayService {
 	public parseIncoming(data: Data): GatewayPacket {
 		if (Buffer.isBuffer(data)) {
 			data = data.toString();
-		}
-		if (typeof data !== 'string') {
-			throw new GatewayError('Invalid incoming message type');
+		} else if (Array.isArray(data)) {
+			data = Buffer.concat(data).toString();
+		} else if (data instanceof ArrayBuffer) {
+			throw new Error('ArrayBuffer not accepted!');
 		}
 		try {
 			return JSON.parse(data);

--- a/src/services/GatewayService.ts
+++ b/src/services/GatewayService.ts
@@ -1,11 +1,50 @@
-import { injectable, inject } from 'tsyringe';
-import { UserService } from './UserService';
+import { injectable } from 'tsyringe';
+import WebSocket, { Data } from 'ws';
+
+export enum GatewayPacketType {
+	Authenticate,
+	Hello
+}
+
+export interface GatewayPacket {
+	t: GatewayPacketType;
+}
+
+export interface AuthenticateGatewayPacket extends GatewayPacket {
+	t: GatewayPacketType.Authenticate;
+	d: {
+		token: string;
+	};
+}
+
+export interface HelloGatewayPacket extends GatewayPacket {
+	t: GatewayPacketType.Hello;
+	d: {
+		time: string;
+	};
+}
+
 
 @injectable()
 export default class GatewayService {
-	private readonly userService: UserService;
+	public parseIncoming(data: Data): GatewayPacket {
+		if (Buffer.isBuffer(data)) {
+			data = data.toString();
+		}
+		if (typeof data !== 'string') {
+			throw new Error('Invalid incoming message type');
+		}
+		return JSON.parse(data);
+	}
 
-	public constructor(@inject(UserService) userService: UserService) {
-		this.userService = userService;
+	private sendData(client: WebSocket, data: string): Promise<void> {
+		return new Promise((resolve, reject) => {
+			client.send(data, error => error ? reject(error) : resolve(error));
+		});
+	}
+
+	public send(clients: WebSocket[], packet: GatewayPacket) {
+		const data = JSON.stringify(packet);
+		return Promise.all(clients.map(client => this.sendData(client, data)));
 	}
 }

--- a/src/services/GatewayService.ts
+++ b/src/services/GatewayService.ts
@@ -1,29 +1,6 @@
 import { injectable } from 'tsyringe';
 import WebSocket, { Data } from 'ws';
-
-export enum GatewayPacketType {
-	Authenticate,
-	Hello
-}
-
-export interface GatewayPacket {
-	t: GatewayPacketType;
-}
-
-export interface AuthenticateGatewayPacket extends GatewayPacket {
-	t: GatewayPacketType.Authenticate;
-	d: {
-		token: string;
-	};
-}
-
-export interface HelloGatewayPacket extends GatewayPacket {
-	t: GatewayPacketType.Hello;
-	d: {
-		time: string;
-	};
-}
-
+import { GatewayPacket, GatewayError } from '../util/gateway';
 
 @injectable()
 export default class GatewayService {
@@ -32,7 +9,7 @@ export default class GatewayService {
 			data = data.toString();
 		}
 		if (typeof data !== 'string') {
-			throw new Error('Invalid incoming message type');
+			throw new GatewayError('Invalid incoming message type');
 		}
 		return JSON.parse(data);
 	}

--- a/src/util/gateway/index.ts
+++ b/src/util/gateway/index.ts
@@ -1,0 +1,21 @@
+export class GatewayError extends Error {}
+
+export enum GatewayPacketType {
+	Identify,
+	Hello
+}
+
+export interface GatewayPacket {
+	t: GatewayPacketType;
+}
+
+export interface IdentifyGatewayPacket extends GatewayPacket {
+	t: GatewayPacketType.Identify;
+	d: {
+		token: string;
+	};
+}
+
+export interface HelloGatewayPacket extends GatewayPacket {
+	t: GatewayPacketType.Hello;
+}

--- a/src/util/gateway/index.ts
+++ b/src/util/gateway/index.ts
@@ -6,16 +6,16 @@ export enum GatewayPacketType {
 }
 
 export interface GatewayPacket {
-	t: GatewayPacketType;
+	type: GatewayPacketType;
 }
 
 export interface IdentifyGatewayPacket extends GatewayPacket {
-	t: GatewayPacketType.Identify;
-	d: {
+	type: GatewayPacketType.Identify;
+	data: {
 		token: string;
 	};
 }
 
 export interface HelloGatewayPacket extends GatewayPacket {
-	t: GatewayPacketType.Hello;
+	type: GatewayPacketType.Hello;
 }

--- a/tests/integration/controllers/gatewayController.test.ts
+++ b/tests/integration/controllers/gatewayController.test.ts
@@ -1,0 +1,40 @@
+import { MockWebSocketServer, MockWebSocket } from '../../util/ws';
+import { createGateway } from '../../../src/';
+
+let wss: MockWebSocketServer;
+
+beforeAll(() => {
+	wss = new MockWebSocketServer();
+	createGateway(wss);
+});
+
+function createWebSocket(): Promise<MockWebSocket> {
+	return new Promise((resolve, reject) => {
+		const ws = new MockWebSocket(wss);
+		ws.once('open', () => resolve(ws));
+		ws.once('error', reject);
+	});
+}
+
+let ws: MockWebSocket;
+
+beforeEach(async () => {
+	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+	if (ws) {
+		ws.close();
+	}
+	ws = await createWebSocket();
+});
+
+function wait() {
+	return new Promise((resolve, reject) => {
+		setTimeout(resolve, 1e3);
+	});
+}
+
+describe('GatewayController', () => {
+	test('test', async () => {
+		ws.send(JSON.stringify({ t: 0 }));
+		expect(ws.readyState === ws.CLOSED);
+	});
+});

--- a/tests/integration/controllers/gatewayController.test.ts
+++ b/tests/integration/controllers/gatewayController.test.ts
@@ -56,7 +56,7 @@ describe('GatewayController', () => {
 		});
 
 		test('Closes for unknown packet', async () => {
-			await ws.send(JSON.stringify({ t: -1 }));
+			await ws.send(JSON.stringify({ type: -1 }));
 			await expect(ws.nextMessage).rejects.toThrow();
 		});
 
@@ -69,8 +69,8 @@ describe('GatewayController', () => {
 	describe('identify', () => {
 		test('Successful flow for valid authorization', async () => {
 			const payload: IdentifyGatewayPacket = {
-				t: GatewayPacketType.Identify,
-				d: {
+				type: GatewayPacketType.Identify,
+				data: {
 					token: '123'
 				}
 			};
@@ -78,15 +78,15 @@ describe('GatewayController', () => {
 			when(spiedVerifyJWT.verifyJWT('123')).thenResolve({ id: '456' });
 			when(mockedUserService.findOne(objectContaining({ id: '456' }))).thenResolve({} as any);
 			await ws.send(JSON.stringify(payload));
-			expect(JSON.parse(await ws.nextMessage)).toMatchObject({ t: GatewayPacketType.Hello });
+			expect(JSON.parse(await ws.nextMessage)).toMatchObject({ type: GatewayPacketType.Hello });
 			verify(spiedVerifyJWT.verifyJWT('123')).once();
 			verify(mockedUserService.findOne(objectContaining({ id: '456' }))).once();
 		});
 
 		test('Closes for invalid authorization', async () => {
 			const payload: IdentifyGatewayPacket = {
-				t: GatewayPacketType.Identify,
-				d: {
+				type: GatewayPacketType.Identify,
+				data: {
 					token: '123'
 				}
 			};
@@ -100,8 +100,8 @@ describe('GatewayController', () => {
 
 		test('Closes for unknown user', async () => {
 			const payload: IdentifyGatewayPacket = {
-				t: GatewayPacketType.Identify,
-				d: {
+				type: GatewayPacketType.Identify,
+				data: {
 					token: '123'
 				}
 			};

--- a/tests/integration/controllers/gatewayController.test.ts
+++ b/tests/integration/controllers/gatewayController.test.ts
@@ -33,11 +33,12 @@ beforeEach(async () => {
 	reset(spiedVerifyJWT);
 	spiedVerifyJWT = spy(auth);
 	reset(mockedUserService);
-	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-	if (ws) {
-		void ws.close();
-	}
 	ws = await createWebSocket();
+	await wait();
+});
+
+afterEach(async () => {
+	await ws.close();
 	await wait();
 });
 

--- a/tests/integration/controllers/gatewayController.test.ts
+++ b/tests/integration/controllers/gatewayController.test.ts
@@ -49,8 +49,13 @@ function wait() {
 
 describe('GatewayController', () => {
 	describe('general', () => {
-		test('Closes for unknown packet', async () => {
+		test('Closes for unknown JSON', async () => {
 			await ws.send(JSON.stringify({ z: 2 }));
+			await expect(ws.nextMessage).rejects.toThrow();
+		});
+
+		test('Closes for unknown packet', async () => {
+			await ws.send(JSON.stringify({ t: -1 }));
 			await expect(ws.nextMessage).rejects.toThrow();
 		});
 

--- a/tests/integration/controllers/gatewayController.test.ts
+++ b/tests/integration/controllers/gatewayController.test.ts
@@ -1,9 +1,20 @@
 import { MockWebSocketServer, MockWebSocket } from '../../util/ws';
 import { createGateway } from '../../../src/';
+import { GatewayPacketType, IdentifyGatewayPacket } from '../../../src/util/gateway';
+import { UserService } from '../../../src/services/UserService';
+import { container } from 'tsyringe';
+import { mock, instance, reset, spy, when, objectContaining, verify, anything } from 'ts-mockito';
+import * as auth from '../../../src/util/auth';
 
+let spiedVerifyJWT: typeof auth;
 let wss: MockWebSocketServer;
+let mockedUserService: UserService;
 
 beforeAll(() => {
+	spiedVerifyJWT = spy(auth);
+	mockedUserService = mock(UserService);
+	container.clearInstances();
+	container.register<UserService>(UserService, { useValue: instance(mockedUserService) });
 	wss = new MockWebSocketServer();
 	createGateway(wss);
 });
@@ -19,22 +30,82 @@ function createWebSocket(): Promise<MockWebSocket> {
 let ws: MockWebSocket;
 
 beforeEach(async () => {
+	reset(spiedVerifyJWT);
+	spiedVerifyJWT = spy(auth);
+	reset(mockedUserService);
 	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
 	if (ws) {
-		ws.close();
+		void ws.close();
 	}
 	ws = await createWebSocket();
+	await wait();
 });
 
 function wait() {
-	return new Promise((resolve, reject) => {
-		setTimeout(resolve, 1e3);
+	return new Promise(resolve => {
+		setImmediate(resolve);
 	});
 }
 
 describe('GatewayController', () => {
-	test('test', async () => {
-		ws.send(JSON.stringify({ t: 0 }));
-		expect(ws.readyState === ws.CLOSED);
+	describe('general', () => {
+		test('Closes for unknown packet', async () => {
+			await ws.send(JSON.stringify({ z: 2 }));
+			await expect(ws.nextMessage).rejects.toThrow();
+		});
+
+		test('Closes for invalid packet', async () => {
+			await ws.send('garbage');
+			await expect(ws.nextMessage).rejects.toThrow();
+		});
+	});
+
+	describe('identify', () => {
+		test('Successful flow for valid authorization', async () => {
+			const payload: IdentifyGatewayPacket = {
+				t: GatewayPacketType.Identify,
+				d: {
+					token: '123'
+				}
+			};
+
+			when(spiedVerifyJWT.verifyJWT('123')).thenResolve({ id: '456' });
+			when(mockedUserService.findOne(objectContaining({ id: '456' }))).thenResolve({} as any);
+			await ws.send(JSON.stringify(payload));
+			expect(JSON.parse(await ws.nextMessage)).toMatchObject({ t: GatewayPacketType.Hello });
+			verify(spiedVerifyJWT.verifyJWT('123')).once();
+			verify(mockedUserService.findOne(objectContaining({ id: '456' }))).once();
+		});
+
+		test('Closes for invalid authorization', async () => {
+			const payload: IdentifyGatewayPacket = {
+				t: GatewayPacketType.Identify,
+				d: {
+					token: '123'
+				}
+			};
+
+			when(spiedVerifyJWT.verifyJWT('123')).thenReject(new Error('Test Error'));
+			await ws.send(JSON.stringify(payload));
+			await expect(ws.nextMessage).rejects.toThrow();
+			verify(spiedVerifyJWT.verifyJWT('123')).once();
+			verify(mockedUserService.findOne(anything())).never();
+		});
+
+		test('Closes for unknown user', async () => {
+			const payload: IdentifyGatewayPacket = {
+				t: GatewayPacketType.Identify,
+				d: {
+					token: '123'
+				}
+			};
+
+			when(spiedVerifyJWT.verifyJWT('123')).thenResolve({ id: '456' });
+			when(mockedUserService.findOne(objectContaining({ id: '456' }))).thenReject(new Error('Test Error'));
+			await ws.send(JSON.stringify(payload));
+			await expect(ws.nextMessage).rejects.toThrow();
+			verify(spiedVerifyJWT.verifyJWT('123')).once();
+			verify(mockedUserService.findOne(objectContaining({ id: '456' }))).once();
+		});
 	});
 });

--- a/tests/unit/services/gatewayService.test.ts
+++ b/tests/unit/services/gatewayService.test.ts
@@ -1,0 +1,31 @@
+import 'reflect-metadata';
+import GatewayService from '../../../src/services/GatewayService';
+import { container } from 'tsyringe';
+
+const gatewayService = container.resolve(GatewayService);
+
+describe('GatewayService', () => {
+	describe('parseIncoming', () => {
+		test('Accepts JSON string', () => {
+			expect(gatewayService.parseIncoming(JSON.stringify({ test: 3 }))).toEqual({ test: 3 });
+		});
+		test('Accepts JSON buffer', () => {
+			expect(gatewayService.parseIncoming(
+				Buffer.from(JSON.stringify({ test: 3 }))
+			)).toEqual({ test: 3 });
+		});
+		test('Accepts JSON buffers', () => {
+			const data = Buffer.from(JSON.stringify({ test: 3 }));
+			expect(gatewayService.parseIncoming([
+				data.slice(0, 12),
+				data.slice(12)
+			])).toEqual({ test: 3 });
+		});
+		test('Rejects invalid data', () => {
+			expect(() => gatewayService.parseIncoming('asdf')).toThrow();
+		});
+		test('Rejects invalid data type', () => {
+			expect(() => gatewayService.parseIncoming(new ArrayBuffer(40))).toThrow(/ArrayBuffer/);
+		});
+	});
+});

--- a/tests/util/ws.ts
+++ b/tests/util/ws.ts
@@ -1,0 +1,118 @@
+/* eslint-disable @typescript-eslint/explicit-member-accessibility */
+import WebSocket, { Server } from 'ws';
+import { EventEmitter } from 'typeorm/platform/PlatformTools';
+
+export class MockWebSocketServer extends EventEmitter implements Server {
+	public options!: WebSocket.ServerOptions;
+	public path!: string;
+	public clients: Set<WebSocket>;
+
+	public constructor() {
+		super();
+		this.clients = new Set();
+		this.emit('listening');
+	}
+
+	public addClient(client: MockWebSocket) {
+		const serverSideClient = new MockWebSocket();
+		serverSideClient.mirror = client;
+		if (!this.clients.has(client)) {
+			this.clients.add(client);
+			setImmediate(() => this.emit('connection', serverSideClient, {}));
+		}
+		return serverSideClient;
+	}
+
+	public address(): string | WebSocket.AddressInfo {
+		throw new Error('Method not implemented.');
+	}
+
+	public close(cb?: (err?: Error) => void): void {
+		for (const client of this.clients) {
+			client.close();
+		}
+		this.emit('close');
+		if (cb) cb();
+	}
+
+	public handleUpgrade(): void {
+		throw new Error('Method not implemented.');
+	}
+
+	public shouldHandle(): boolean | Promise<boolean> {
+		throw new Error('Method not implemented.');
+	}
+}
+
+
+export class MockWebSocket extends EventEmitter implements WebSocket {
+	public binaryType!: string;
+	public bufferedAmount!: number;
+	public extensions!: string;
+	public protocol!: string;
+	public readyState: number;
+	public url!: string;
+	public CONNECTING = WebSocket.CONNECTING;
+	public OPEN = WebSocket.OPEN;
+	public CLOSING = WebSocket.CLOSING;
+	public CLOSED = WebSocket.CLOSED;
+	public mirror!: MockWebSocket;
+	public messages: string[];
+	public onopen!: (event: WebSocket.OpenEvent) => void;
+	public onerror!: (event: WebSocket.ErrorEvent) => void;
+	public onclose!: (event: WebSocket.CloseEvent) => void;
+	public onmessage!: (event: WebSocket.MessageEvent) => void;
+
+	public constructor(server?: MockWebSocketServer) {
+		super();
+		setImmediate(() => this.emit('open'));
+		if (server) {
+			this.mirror = server.addClient(this);
+			setImmediate(() => this.mirror.emit('open'));
+		}
+		this.messages = [];
+		this.on('message', data => {
+			this.messages.push(data);
+		});
+		this.readyState = this.OPEN;
+	}
+
+	public close(code?: number, reason?: string): void {
+		this.mirror.emit('close', code, reason);
+		this.readyState = this.CLOSED;
+		this.mirror.readyState = this.CLOSED;
+	}
+
+	public ping(data?: any, mask?: boolean, cb?: (err: any) => void): Promise<void> {
+		this.mirror.emit('ping', data);
+		if (cb) cb(undefined);
+		return Promise.resolve();
+	}
+
+	public pong(data?: any, mask?: boolean, cb?: (err: any) => void): Promise<void> {
+		this.mirror.emit('pong', data);
+		if (cb) cb(undefined);
+		return Promise.resolve();
+	}
+
+	public send(data: any, options?: any, cb?: (err: any) => void): Promise<void> {
+		this.mirror.emit('message', data);
+		if (cb) cb(undefined);
+		return Promise.resolve();
+	}
+
+	public terminate(): Promise<void> {
+		this.mirror.emit('close');
+		this.readyState = this.CLOSED;
+		this.mirror.readyState = this.CLOSED;
+		return Promise.resolve();
+	}
+
+	public addEventListener() {
+		throw new Error('Method not implemented.');
+	}
+
+	public removeEventListener() {
+		throw new Error('Method not implemented.');
+	}
+}


### PR DESCRIPTION
## About

Partially addresses #31. The gateway specification in this PR is by no means finished, I just wanted to have the gateway setup so we could develop with it in mind, and even test it if needed.

This PR implements a basic gateway with the current flow:

1. Client connects
2. Client sends `IDENTIFY` packet:
    ```json
    {
      "type": 0,
      "data": {
        "token": "their JWT here"
      }
    }
    ```
3. If their authorization is valid, the gateway sends back a `HELLO` packet:
    ```json
    {
      "type": 1
    }
    ```
    Otherwise, the gateway will close the client's connection.

## Testing

I was dreading writing these tests! I think I have come up with a better solution than actually launching the gateway on a HTTP server. My solution was to partially mock the `ws` library - I mocked features we would actually use. I also introduced some helper functionality, e.g. `client.nextMessage` to make testing straightforward. This allows for some pretty easy testing of the gateway implementation:

```js
// Somewhere at the top
const wss = new MockWebSocketServer();
createGateway(wss); // binds logic to the websocket server

// Somewhere else
const client = new MockWebSocket(wss);
await client.send(message);
const response = await client.nextMessage;
// do something with the response...
```