### PR TITLE
refactor(users): allow fetching of users with no profile

### DIFF
--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -11,8 +11,8 @@ import { APIError } from '../util/errors';
 	improve error handling, use more enums, do not expose raw errors to enduser
 */
 
-enum GetUserProfileError {
-	ProfileNotFound = 'Profile not found',
+enum GetUserError {
+	UserNotFound = 'User not found',
 }
 
 @injectable()
@@ -58,12 +58,12 @@ export class UserController {
 		}
 	}
 
-	public async getUserProfile(req: Request & { params: { id: string } }, res: AuthenticatedResponse, next: NextFunction): Promise<void> {
+	public async getUser(req: Request & { params: { id: string } }, res: AuthenticatedResponse, next: NextFunction): Promise<void> {
 		try {
-			if (!req.params.id) throw new APIError(404, GetUserProfileError.ProfileNotFound);
+			if (!req.params.id) throw new APIError(404, GetUserError.UserNotFound);
 			if (req.params.id === '@me') req.params.id = res.locals.user.id;
 			const user = await this.userService.findOne({ id: req.params.id });
-			if (!user || !user.profile) throw new APIError(404, GetUserProfileError.ProfileNotFound);
+			if (!user) throw new APIError(404, GetUserError.UserNotFound);
 			res.json({
 				user: user.toLimitedJSON()
 			});

--- a/src/routes/UserRoutes.ts
+++ b/src/routes/UserRoutes.ts
@@ -18,7 +18,7 @@ export class UserRoutes {
 
 		router.post('/authenticate', this.userController.authenticate.bind(this.userController));
 
-		router.get('/users/:id/profile', getUser, isVerified, this.userController.getUserProfile.bind(this.userController));
+		router.get('/users/:id', getUser, isVerified, this.userController.getUser.bind(this.userController));
 
 		router.put('/users/@me/profile', getUser, isVerified, this.userController.putUserProfile.bind(this.userController));
 	}


### PR DESCRIPTION
The current implementation of `getUserProfile` requires a user to have a profile to receive any data. This means that newly created accounts are not even allowed to query `/api/v1/users/@me/profile` since they won't have a profile...

This pull request aims to "merge" the User and Profile entities and treat the Profile less as a separate entity, but more as a property of a User (as it should be!)

Instead of fetching from a `/users/:id/profile` endpoint, you now fetch from a `/users/:id` endpoint, which returns the user object, with `profile` as a property _if_ the user has one.