### PR TITLE
feat: add event channels and messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1144,6 +1144,12 @@
         "@types/superagent": "*"
       }
     },
+    "@types/uuid": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.0.0.tgz",
+      "integrity": "sha512-xSQfNcvOiE5f9dyd4Kzxbof1aTrLobL278pGLKOZI6esGfZ7ts9Ka16CzIN6Y8hFHE1C7jIBZokULhK1bOgjRw==",
+      "dev": true
+    },
     "@types/validator": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.0.0.tgz",
@@ -5094,6 +5100,15 @@
         "shellwords": "^0.1.1",
         "uuid": "^7.0.3",
         "which": "^2.0.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "normalize-package-data": {
@@ -7103,11 +7118,10 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
-      "dev": true,
-      "optional": true
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==",
+      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "@types/jest": "^26.0.4",
   "@types/node": "^14.0.22",
   "@types/supertest": "^2.0.10",
+  "@types/uuid": "^8.0.0",
   "@typescript-eslint/eslint-plugin": "^3.6.0",
   "@typescript-eslint/parser": "^3.6.0",
   "@unicsmcr/eslint-config": "0.0.2",
@@ -40,7 +41,8 @@
   "supertest": "^4.0.2",
   "ts-jest": "^26.1.1",
   "ts-mockito": "^2.6.1",
-  "typescript": "^3.9.6"
+  "typescript": "^3.9.6",
+  "uuid": "^8.3.0"
  },
  "eslintConfig": {
   "extends": "@unicsmcr",

--- a/src/controllers/MessageController.ts
+++ b/src/controllers/MessageController.ts
@@ -2,6 +2,7 @@ import { NextFunction, Request } from 'express';
 import { inject, injectable } from 'tsyringe';
 import { AuthenticatedResponse } from '../routes/middleware/getUser';
 import MessageService from '../services/MessageService';
+import { AccountType } from '../entities/User';
 
 @injectable()
 export class MessageController {
@@ -36,6 +37,19 @@ export class MessageController {
 				page: Number(req.query.page)
 			});
 			res.json({ messages });
+		} catch (error) {
+			next(error);
+		}
+	}
+
+	public async deleteMessage(req: Request & { params: { channelID: string; messageID: string } }, res: AuthenticatedResponse, next: NextFunction): Promise<void> {
+		try {
+			await this.messageService.deleteMessage({
+				id: req.params.messageID,
+				channelID: req.params.channelID,
+				authorID: res.locals.user.accountType === AccountType.Admin ? undefined : res.locals.user.id
+			});
+			res.status(204).end();
 		} catch (error) {
 			next(error);
 		}

--- a/src/controllers/MessageController.ts
+++ b/src/controllers/MessageController.ts
@@ -34,7 +34,8 @@ export class MessageController {
 		try {
 			const messages = await this.messageService.getMessages({
 				channelID: req.params.channelID,
-				page: Number(req.query.page)
+				page: Number(req.query.page),
+				count: 50
 			});
 			res.json({ messages });
 		} catch (error) {

--- a/src/controllers/MessageController.ts
+++ b/src/controllers/MessageController.ts
@@ -1,0 +1,22 @@
+import { NextFunction, Request } from 'express';
+import { inject, injectable } from 'tsyringe';
+import { AuthenticatedResponse } from '../routes/middleware/getUser';
+import MessageService from '../services/MessageService';
+
+@injectable()
+export class MessageController {
+	private readonly messageService: MessageService;
+
+	public constructor(@inject(MessageService) messageService: MessageService) {
+		this.messageService = messageService;
+	}
+
+	public async createMessage(req: Request & { params: { channelID: string } }, res: AuthenticatedResponse, next: NextFunction): Promise<void> {
+		try {
+			const message = await this.messageService.createMessage({ ...req.body, channelID: req.params.channelID, authorID: res.locals.user.id });
+			res.json({ message });
+		} catch (error) {
+			next(error);
+		}
+	}
+}

--- a/src/controllers/MessageController.ts
+++ b/src/controllers/MessageController.ts
@@ -28,4 +28,16 @@ export class MessageController {
 			next(error);
 		}
 	}
+
+	public async getMessages(req: Request & { params: { channelID: string; page: number } }, res: AuthenticatedResponse, next: NextFunction): Promise<void> {
+		try {
+			const messages = await this.messageService.getMessages({
+				channelID: req.params.channelID,
+				page: Number(req.query.page)
+			});
+			res.json({ messages });
+		} catch (error) {
+			next(error);
+		}
+	}
 }

--- a/src/controllers/MessageController.ts
+++ b/src/controllers/MessageController.ts
@@ -3,6 +3,7 @@ import { inject, injectable } from 'tsyringe';
 import { AuthenticatedResponse } from '../routes/middleware/getUser';
 import MessageService from '../services/MessageService';
 import { AccountType } from '../entities/User';
+import { HttpCode } from '../util/errors';
 
 @injectable()
 export class MessageController {
@@ -50,7 +51,7 @@ export class MessageController {
 				channelID: req.params.channelID,
 				authorID: res.locals.user.accountType === AccountType.Admin ? undefined : res.locals.user.id
 			});
-			res.status(204).end();
+			res.status(HttpCode.NoContent).end();
 		} catch (error) {
 			next(error);
 		}

--- a/src/controllers/MessageController.ts
+++ b/src/controllers/MessageController.ts
@@ -19,4 +19,13 @@ export class MessageController {
 			next(error);
 		}
 	}
+
+	public async getMessage(req: Request & { params: { channelID: string; messageID: string } }, res: AuthenticatedResponse, next: NextFunction): Promise<void> {
+		try {
+			const message = await this.messageService.getMessage({ id: req.params.messageID, channelID: req.params.channelID });
+			res.json({ message });
+		} catch (error) {
+			next(error);
+		}
+	}
 }

--- a/src/entities/Channel.ts
+++ b/src/entities/Channel.ts
@@ -1,4 +1,4 @@
-import { PrimaryGeneratedColumn, OneToOne, Entity, TableInheritance, ChildEntity, JoinColumn } from 'typeorm';
+import { PrimaryGeneratedColumn, OneToOne, Entity, TableInheritance, ChildEntity } from 'typeorm';
 import { Event } from './Event';
 
 @Entity()

--- a/src/entities/Channel.ts
+++ b/src/entities/Channel.ts
@@ -1,14 +1,15 @@
-import { PrimaryGeneratedColumn, OneToOne, Entity } from 'typeorm';
+import { PrimaryGeneratedColumn, OneToOne, Entity, TableInheritance, ChildEntity, JoinColumn } from 'typeorm';
 import { Event } from './Event';
-export abstract class Channel {
-	public abstract id: string;
-}
 
 @Entity()
-export class EventChannel implements Channel {
+@TableInheritance({ column: { type: 'varchar', name: 'type' } })
+export class Channel {
 	@PrimaryGeneratedColumn('uuid')
 	public id!: string;
+}
 
+@ChildEntity()
+export class EventChannel extends Channel {
 	@OneToOne(() => Event, event => event.channel)
 	public event!: Event;
 }

--- a/src/entities/Channel.ts
+++ b/src/entities/Channel.ts
@@ -1,0 +1,14 @@
+import { PrimaryGeneratedColumn, OneToOne, Entity } from 'typeorm';
+import { Event } from './Event';
+export abstract class Channel {
+	public abstract id: string;
+}
+
+@Entity()
+export class EventChannel implements Channel {
+	@PrimaryGeneratedColumn('uuid')
+	public id!: string;
+
+	@OneToOne(() => Event, event => event.channel)
+	public event!: Event;
+}

--- a/src/entities/Event.ts
+++ b/src/entities/Event.ts
@@ -1,5 +1,16 @@
-import { PrimaryGeneratedColumn, Entity, Column } from 'typeorm';
-import { MaxLength, IsString } from 'class-validator';
+import { PrimaryGeneratedColumn, Entity, Column, OneToOne, JoinColumn } from 'typeorm';
+import { MaxLength, IsString, IsDate } from 'class-validator';
+import { EventChannel } from './Channel';
+
+export interface APIEvent {
+	id: string;
+	title: string;
+	startTime: string;
+	endTime: string;
+	description: string;
+	external: string;
+	channelID: string;
+}
 
 @Entity()
 export class Event {
@@ -12,9 +23,11 @@ export class Event {
 	public title!: string;
 
 	@Column('timestamp')
+	@IsDate()
 	public startTime!: Date;
 
 	@Column('timestamp')
+	@IsDate()
 	public endTime!: Date;
 
 	@Column()
@@ -25,4 +38,21 @@ export class Event {
 	@Column()
 	@IsString()
 	public external!: string;
+
+	@OneToOne(() => EventChannel, channel => channel.event, { nullable: true, eager: true, cascade: true })
+	@JoinColumn()
+	public channel!: EventChannel;
+
+	public toJSON(): APIEvent {
+		const { id, title, startTime, endTime, description, external, channel } = this;
+		return {
+			id,
+			title,
+			startTime: startTime.toISOString(),
+			endTime: endTime.toISOString(),
+			description,
+			external,
+			channelID: channel.id
+		};
+	}
 }

--- a/src/entities/Message.ts
+++ b/src/entities/Message.ts
@@ -1,0 +1,11 @@
+import { Entity, PrimaryGeneratedColumn, ManyToOne } from 'typeorm';
+import { Channel } from './Channel';
+
+@Entity()
+export default class Message {
+	@PrimaryGeneratedColumn('uuid')
+	public id!: string;
+
+	@ManyToOne(() => Channel)
+	public channel!: Channel;
+}

--- a/src/entities/Message.ts
+++ b/src/entities/Message.ts
@@ -3,15 +3,23 @@ import { Channel } from './Channel';
 import { User } from './User';
 import { IsDate, IsString, MaxLength } from 'class-validator';
 
+export interface APIMessage {
+	id: string;
+	channelID: string;
+	authorID: string;
+	content: string;
+	time: string;
+}
+
 @Entity()
 export default class Message {
 	@PrimaryGeneratedColumn('uuid')
 	public id!: string;
 
-	@ManyToOne(() => Channel)
+	@ManyToOne(() => Channel, { eager: true })
 	public channel!: Channel;
 
-	@ManyToOne(() => User)
+	@ManyToOne(() => User, { eager: true })
 	public author!: User;
 
 	@Column()
@@ -22,4 +30,14 @@ export default class Message {
 	@Column('timestamp')
 	@IsDate()
 	public time!: Date;
+
+	public toJSON(): APIMessage {
+		return {
+			id: this.id,
+			channelID: this.channel.id,
+			authorID: this.author.id,
+			content: this.content,
+			time: this.time.toISOString()
+		};
+	}
 }

--- a/src/entities/Message.ts
+++ b/src/entities/Message.ts
@@ -1,5 +1,7 @@
-import { Entity, PrimaryGeneratedColumn, ManyToOne } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, ManyToOne, Column } from 'typeorm';
 import { Channel } from './Channel';
+import { User } from './User';
+import { IsDate, IsString, MaxLength } from 'class-validator';
 
 @Entity()
 export default class Message {
@@ -8,4 +10,16 @@ export default class Message {
 
 	@ManyToOne(() => Channel)
 	public channel!: Channel;
+
+	@ManyToOne(() => User)
+	public author!: User;
+
+	@Column()
+	@IsString()
+	@MaxLength(400, { message: 'A message can be 400 characters at most' })
+	public content!: string;
+
+	@Column('timestamp')
+	@IsDate()
+	public time!: Date;
 }

--- a/src/entities/Message.ts
+++ b/src/entities/Message.ts
@@ -1,7 +1,7 @@
 import { Entity, PrimaryGeneratedColumn, ManyToOne, Column } from 'typeorm';
 import { Channel } from './Channel';
 import { User } from './User';
-import { IsDate, IsString, MaxLength } from 'class-validator';
+import { IsDate, IsString, MaxLength, MinLength } from 'class-validator';
 
 export interface APIMessage {
 	id: string;
@@ -24,6 +24,7 @@ export default class Message {
 
 	@Column()
 	@IsString()
+	@MinLength(1, { message: 'A message must be at least 1 character long' })
 	@MaxLength(400, { message: 'A message can be 400 characters at most' })
 	public content!: string;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import MockEmailService from './services/email/MockEmailService';
 import { APIError } from './util/errors';
 import { Event } from './entities/Event';
 import { EventRoutes } from './routes/EventRoutes';
-import { EventChannel } from './entities/Channel';
+import { EventChannel, Channel } from './entities/Channel';
 
 export function createExpress() {
 	const app = express();
@@ -63,7 +63,7 @@ export async function createDBConnection() {
 		type: 'postgres',
 		...getConfig().db, // username, password, host, port, database
 		entities: [
-			User, EmailConfirmation, Profile, Event, EventChannel
+			User, EmailConfirmation, Profile, Event, Channel, EventChannel
 		],
 		synchronize: true,
 		logging: false

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,20 +8,14 @@ import express, { Router, Response, Request, NextFunction } from 'express';
 
 import { createConnection } from 'typeorm';
 import { getConfig } from './util/config';
-import { User } from './entities/User';
 import { UserRoutes } from './routes/UserRoutes';
-import { EmailConfirmation } from './entities/EmailConfirmation';
 import { container } from 'tsyringe';
-import Profile from './entities/Profile';
 import EmailService from './services/email/EmailService';
 import MockEmailService from './services/email/MockEmailService';
 import { APIError } from './util/errors';
 import { Server as WebSocketServer } from 'ws';
 import GatewayController from './controllers/GatewayController';
-import { Event } from './entities/Event';
 import { EventRoutes } from './routes/EventRoutes';
-import { EventChannel, Channel } from './entities/Channel';
-import Message from './entities/Message';
 import { MessageRoutes } from './routes/MessageRoutes';
 
 export function createExpress() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ export async function createDBConnection() {
 		type: 'postgres',
 		...getConfig().db, // username, password, host, port, database
 		entities: [
-			User, EmailConfirmation, Profile, Event, Channel, EventChannel, Message
+			`${__dirname}/entities/**/*{.js,.ts}`
 		],
 		synchronize: true,
 		logging: false

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import MockEmailService from './services/email/MockEmailService';
 import { APIError } from './util/errors';
 import { Event } from './entities/Event';
 import { EventRoutes } from './routes/EventRoutes';
+import { EventChannel } from './entities/Channel';
 
 export function createExpress() {
 	const app = express();
@@ -62,7 +63,7 @@ export async function createDBConnection() {
 		type: 'postgres',
 		...getConfig().db, // username, password, host, port, database
 		entities: [
-			User, EmailConfirmation, Profile, Event
+			User, EmailConfirmation, Profile, Event, EventChannel
 		],
 		synchronize: true,
 		logging: false

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import { Event } from './entities/Event';
 import { EventRoutes } from './routes/EventRoutes';
 import { EventChannel, Channel } from './entities/Channel';
 import Message from './entities/Message';
+import { MessageRoutes } from './routes/MessageRoutes';
 
 export function createExpress() {
 	const app = express();
@@ -38,6 +39,7 @@ export function createExpress() {
 
 	container.resolve(UserRoutes).routes(router);
 	container.resolve(EventRoutes).routes(router);
+	container.resolve(MessageRoutes).routes(router);
 
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	app.use((err: any, req: Request, res: Response, next: NextFunction) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { APIError } from './util/errors';
 import { Event } from './entities/Event';
 import { EventRoutes } from './routes/EventRoutes';
 import { EventChannel, Channel } from './entities/Channel';
+import Message from './entities/Message';
 
 export function createExpress() {
 	const app = express();
@@ -63,7 +64,7 @@ export async function createDBConnection() {
 		type: 'postgres',
 		...getConfig().db, // username, password, host, port, database
 		entities: [
-			User, EmailConfirmation, Profile, Event, Channel, EventChannel
+			User, EmailConfirmation, Profile, Event, Channel, EventChannel, Message
 		],
 		synchronize: true,
 		logging: false

--- a/src/routes/MessageRoutes.ts
+++ b/src/routes/MessageRoutes.ts
@@ -13,5 +13,6 @@ export class MessageRoutes {
 
 	public routes(router: Router): void {
 		router.post('/channels/:channelID/messages', getUser, isVerified, this.messageController.createMessage.bind(this.messageController));
+		router.get('/channels/:channelID/messages/:messageID', getUser, isVerified, this.messageController.getMessage.bind(this.messageController));
 	}
 }

--- a/src/routes/MessageRoutes.ts
+++ b/src/routes/MessageRoutes.ts
@@ -1,0 +1,17 @@
+import { Router } from 'express';
+import { inject, injectable } from 'tsyringe';
+import { getUser, isVerified } from './middleware';
+import { MessageController } from '../controllers/MessageController';
+
+@injectable()
+export class MessageRoutes {
+	private readonly messageController: MessageController;
+
+	public constructor(@inject(MessageController) messageController: MessageController) {
+		this.messageController = messageController;
+	}
+
+	public routes(router: Router): void {
+		router.post('/channels/:channelID/messages', getUser, isVerified, this.messageController.createMessage.bind(this.messageController));
+	}
+}

--- a/src/routes/MessageRoutes.ts
+++ b/src/routes/MessageRoutes.ts
@@ -14,5 +14,6 @@ export class MessageRoutes {
 	public routes(router: Router): void {
 		router.post('/channels/:channelID/messages', getUser, isVerified, this.messageController.createMessage.bind(this.messageController));
 		router.get('/channels/:channelID/messages/:messageID', getUser, isVerified, this.messageController.getMessage.bind(this.messageController));
+		router.get('/channels/:channelID/messages', getUser, isVerified, this.messageController.getMessages.bind(this.messageController));
 	}
 }

--- a/src/routes/MessageRoutes.ts
+++ b/src/routes/MessageRoutes.ts
@@ -13,7 +13,8 @@ export class MessageRoutes {
 
 	public routes(router: Router): void {
 		router.post('/channels/:channelID/messages', getUser, isVerified, this.messageController.createMessage.bind(this.messageController));
-		router.get('/channels/:channelID/messages/:messageID', getUser, isVerified, this.messageController.getMessage.bind(this.messageController));
 		router.get('/channels/:channelID/messages', getUser, isVerified, this.messageController.getMessages.bind(this.messageController));
+		router.get('/channels/:channelID/messages/:messageID', getUser, isVerified, this.messageController.getMessage.bind(this.messageController));
+		router.delete('/channels/:channelID/messages/:messageID', getUser, isVerified, this.messageController.deleteMessage.bind(this.messageController));
 	}
 }

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -1,8 +1,14 @@
 import { singleton } from 'tsyringe';
 import Message, { APIMessage } from '../entities/Message';
 import { getRepository } from 'typeorm';
+import { APIError } from '../util/errors';
 
 type MessageCreationData = Omit<APIMessage, 'id' | 'time'>;
+
+enum GetMessageError {
+	NotFound = 'Message not found',
+	InvalidChannel = 'Message does not exist for given channel'
+}
 
 @singleton()
 export default class MessageService {
@@ -13,5 +19,12 @@ export default class MessageService {
 		message.author = { id: data.authorID } as any;
 		message.channel = { id: data.channelID } as any;
 		return (await getRepository(Message).save(message)).toJSON();
+	}
+
+	public async getMessage(data: Pick<APIMessage, 'id' | 'channelID'>): Promise<APIMessage> {
+		if (!data.id) throw new APIError(404, GetMessageError.NotFound);
+		const message = await getRepository(Message).findOneOrFail(data.id).catch(() => Promise.reject(new APIError(404, GetMessageError.NotFound)));
+		if (message.channel.id !== data.channelID) throw new APIError(400, GetMessageError.InvalidChannel);
+		return message.toJSON();
 	}
 }

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -6,7 +6,7 @@ import { validateOrReject } from 'class-validator';
 
 const PAGINATION_COUNT = 50;
 
-type MessageCreationData = Omit<APIMessage, 'id' | 'time'>;
+type MessageCreationData = Omit<APIMessage, 'id'>;
 
 enum GetMessageError {
 	NotFound = 'Message not found',
@@ -29,7 +29,7 @@ export default class MessageService {
 	public async createMessage(data: MessageCreationData): Promise<APIMessage> {
 		const message = new Message();
 		message.content = data.content;
-		message.time = new Date();
+		message.time = new Date(data.time);
 		message.author = { id: data.authorID } as any;
 		message.channel = { id: data.channelID } as any;
 		await validateOrReject(message).catch(e => Promise.reject(formatValidationErrors(e)));

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -1,0 +1,17 @@
+import { singleton } from 'tsyringe';
+import Message, { APIMessage } from '../entities/Message';
+import { getRepository } from 'typeorm';
+
+type MessageCreationData = Omit<APIMessage, 'id' | 'time'>;
+
+@singleton()
+export default class MessageService {
+	public async createMessage(data: MessageCreationData): Promise<APIMessage> {
+		const message = new Message();
+		message.content = data.content;
+		message.time = new Date();
+		message.author = { id: data.authorID } as any;
+		message.channel = { id: data.channelID } as any;
+		return (await getRepository(Message).save(message)).toJSON();
+	}
+}

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -1,7 +1,8 @@
 import { singleton } from 'tsyringe';
 import Message, { APIMessage } from '../entities/Message';
 import { getRepository } from 'typeorm';
-import { APIError } from '../util/errors';
+import { APIError, formatValidationErrors } from '../util/errors';
+import { validateOrReject } from 'class-validator';
 
 const PAGINATION_COUNT = 50;
 
@@ -31,6 +32,7 @@ export default class MessageService {
 		message.time = new Date();
 		message.author = { id: data.authorID } as any;
 		message.channel = { id: data.channelID } as any;
+		await validateOrReject(message).catch(e => Promise.reject(formatValidationErrors(e)));
 		return (await getRepository(Message).save(message)).toJSON();
 	}
 

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -46,14 +46,12 @@ export default class MessageService {
 		if (!data.channelID) throw new APIError(404, GetMessagesError.ChannelNotFound);
 		const channel = await getRepository(Channel).findOneOrFail(data.channelID).catch(() => Promise.reject(new APIError(404, GetMessagesError.ChannelNotFound)));
 		const messages = await getRepository(Message)
-			.createQueryBuilder('message')
-			.leftJoinAndSelect('message.channel', 'channel')
-			.leftJoinAndSelect('message.author', 'author')
-			.where('channel.id = :id', { id: channel.id })
-			.orderBy('message.time', 'DESC')
-			.skip(data.count * data.page)
-			.take(data.count)
-			.getMany();
+			.find({
+				where: { channel },
+				order: { time: 'DESC' },
+				skip: data.count * data.page,
+				take: data.count
+			});
 		return messages.map(message => message.toJSON());
 	}
 

--- a/tests/fixtures/events.ts
+++ b/tests/fixtures/events.ts
@@ -1,4 +1,5 @@
 import { Event } from '../../src/entities/Event';
+import { EventChannel } from '../../src/entities/Channel';
 
 const event1 = new Event();
 event1.id = '8e45cdcc-bc99-4844-a89b-31a5f2beedcb';
@@ -8,6 +9,11 @@ event1.title = 'UniCS Test Event!';
 event1.description = 'A description of the first UniCS online event';
 event1.external = 'https://facebook.com/a/link';
 
+const event1Channel = new EventChannel();
+event1Channel.event = event1;
+event1Channel.id = 'a265e2ad-4049-4896-aed9-5211ad44f351';
+event1.channel = event1Channel;
+
 const event2 = new Event();
 event2.id = 'e50fa6a6-090b-4013-be44-f27bf2e85cad';
 event2.startTime = new Date('Thu Sep 17 2020 17:00:00 GMT+0100 (British Summer Time)');
@@ -15,6 +21,11 @@ event2.endTime = new Date('Tue Jul 20 2021 17:00:00 GMT+0100 (British Summer Tim
 event2.title = 'UniCS Year 1';
 event2.description = 'A very long event!';
 event2.external = 'https://unicsmcr.com/a/link/to/a/page';
+
+const event2Channel = new EventChannel();
+event2Channel.event = event2;
+event2Channel.id = 'cfcc86ef-3b0e-4ce6-8706-db1c9f5952e4';
+event2.channel = event2Channel;
 
 export default [
 	event1, event2

--- a/tests/fixtures/messages.ts
+++ b/tests/fixtures/messages.ts
@@ -4,8 +4,9 @@ import { User, AccountStatus } from '../../src/entities/User';
 import { Channel } from '../../src/entities/Channel';
 import users from './users';
 import events from './events';
+import { v4 as uuidv4 } from 'uuid';
 
-export function createMessage(data: { author?: User; channel?: Channel; content?: string }): [Pick<APIMessage, 'content' | 'authorID' | 'channelID' | 'time'>, APIMessage] {
+export function createMessage(data: { author?: User; channel?: Channel; content?: string }): [Pick<APIMessage, 'content' | 'authorID' | 'channelID' | 'time'>, Message] {
 	const concreteData = {
 		author: data.author ?? users.find(user => user.accountStatus === AccountStatus.Verified)!,
 		channel: data.channel ?? events[0].channel,
@@ -16,6 +17,7 @@ export function createMessage(data: { author?: User; channel?: Channel; content?
 	message.content = concreteData.content;
 	message.author = concreteData.author;
 	message.channel = concreteData.channel;
+	message.id = uuidv4();
 
 	return [
 		{
@@ -24,6 +26,6 @@ export function createMessage(data: { author?: User; channel?: Channel; content?
 			content: concreteData.content,
 			time: message.time.toISOString()
 		},
-		message.toJSON()
+		message
 	];
 }

--- a/tests/fixtures/messages.ts
+++ b/tests/fixtures/messages.ts
@@ -6,14 +6,15 @@ import users from './users';
 import events from './events';
 import { v4 as uuidv4 } from 'uuid';
 
-export function createMessage(data: { author?: User; channel?: Channel; content?: string }): [Pick<APIMessage, 'content' | 'authorID' | 'channelID' | 'time'>, Message] {
+export function createMessage(data: { author?: User; channel?: Channel; content?: string; time?: Date }): [Pick<APIMessage, 'content' | 'authorID' | 'channelID' | 'time'>, Message] {
 	const concreteData = {
 		author: data.author ?? users.find(user => user.accountStatus === AccountStatus.Verified)!,
 		channel: data.channel ?? events[0].channel,
-		content: data.content ?? randomBytes(128).toString('hex')
+		content: data.content ?? randomBytes(128).toString('hex'),
+		time: data.time ?? new Date()
 	};
 	const message = new Message();
-	message.time = new Date();
+	message.time = concreteData.time;
 	message.content = concreteData.content;
 	message.author = concreteData.author;
 	message.channel = concreteData.channel;

--- a/tests/fixtures/messages.ts
+++ b/tests/fixtures/messages.ts
@@ -20,6 +20,9 @@ export function createMessage(data: { author?: User; channel?: Channel; content?
 	message.channel = concreteData.channel;
 	message.id = uuidv4();
 
+	/*
+		Warning! The returned message ID is not guaranteed to be the same as the ID of the message created with the given fixture data.
+	*/
 	return [
 		{
 			authorID: concreteData.author.id,

--- a/tests/fixtures/messages.ts
+++ b/tests/fixtures/messages.ts
@@ -1,0 +1,29 @@
+import Message, { APIMessage } from '../../src/entities/Message';
+import { randomBytes } from 'crypto';
+import { User, AccountStatus } from '../../src/entities/User';
+import { Channel } from '../../src/entities/Channel';
+import users from './users';
+import events from './events';
+
+export function createMessage(data: { author?: User; channel?: Channel; content?: string }): [Pick<APIMessage, 'content' | 'authorID' | 'channelID' | 'time'>, APIMessage] {
+	const concreteData = {
+		author: data.author ?? users.find(user => user.accountStatus === AccountStatus.Verified)!,
+		channel: data.channel ?? events[0].channel,
+		content: data.content ?? randomBytes(128).toString('hex')
+	};
+	const message = new Message();
+	message.time = new Date();
+	message.content = concreteData.content;
+	message.author = concreteData.author;
+	message.channel = concreteData.channel;
+
+	return [
+		{
+			authorID: concreteData.author.id,
+			channelID: concreteData.channel.id,
+			content: concreteData.content,
+			time: message.time.toISOString()
+		},
+		message.toJSON()
+	];
+}

--- a/tests/integration/controllers/messageController.test.ts
+++ b/tests/integration/controllers/messageController.test.ts
@@ -1,0 +1,90 @@
+import { createApp } from '../../../src';
+import { mock, instance, when, anything, verify, objectContaining, reset } from 'ts-mockito';
+import { container } from 'tsyringe';
+import supertest from 'supertest';
+import '../../util/dbTeardown';
+import users from '../../fixtures/users';
+import { APIError } from '../../../src/util/errors';
+import * as getUserMiddleware from '../../../src/routes/middleware/getUser';
+import { User, AccountType, AccountStatus } from '../../../src/entities/User';
+import MessageService from '../../../src/services/MessageService';
+
+let app: Express.Application;
+let mockedMessageService: MessageService;
+
+beforeAll(async () => {
+	mockedMessageService = mock(MessageService);
+	container.clearInstances();
+	container.register<MessageService>(MessageService, { useValue: instance(mockedMessageService) });
+
+	app = await createApp();
+});
+
+beforeEach(() => {
+	reset(mockedMessageService);
+});
+
+const randomNumber = () => Date.now() + Math.floor(Math.random() * 10e9);
+const randomString = () => String(randomNumber());
+const randomObject = () => ({ tag: randomString() }) as any;
+const testError400 = new APIError(400, 'EventController test error');
+
+describe('MessageController', () => {
+	const spiedGetUser = jest.spyOn(getUserMiddleware, 'default');
+	const adminUser = users.find(user => user.accountType === AccountType.Admin)!;
+	const normalUser = users.find(user => user.accountType === AccountType.User)!;
+	const verifiedUser = users.find(user => user.accountType === AccountType.User && user.accountStatus === AccountStatus.Verified)!;
+
+	function setGetUserAllowed(authorization: string, user: User) {
+		spiedGetUser.mockImplementation((req, res, next) => {
+			if (req.headers.authorization === authorization) res.locals.user = user;
+			next();
+			return Promise.resolve();
+		});
+	}
+
+	afterEach(() => {
+		spiedGetUser.mockReset();
+	});
+
+	describe('createMessage', () => {
+		test('200 for valid request', async () => {
+			const message = randomObject();
+			const authorization = randomString();
+			setGetUserAllowed(authorization, verifiedUser);
+			when(mockedMessageService.createMessage(objectContaining(message))).thenResolve(message);
+			const res = await supertest(app).post('/api/v1/channels/id_placeholder/messages').send(message)
+				.set('Authorization', authorization);
+			expect(res.body).toEqual({ message });
+			expect(res.status).toEqual(200);
+			verify(mockedMessageService.createMessage(objectContaining(message))).once();
+		});
+
+		test('401 for missing/invalid authorization', async () => {
+			const message = randomObject();
+			setGetUserAllowed(randomString(), verifiedUser);
+			when(mockedMessageService.createMessage(objectContaining(message))).thenResolve(message);
+
+			await expect(supertest(app).post('/api/v1/channels/id_placeholder/messages').send(message)).resolves.toMatchObject({ status: 401 });
+			await expect(supertest(app).post('/api/v1/channels/id_placeholder/messages').send(message)
+				.set('Authorization', 'fake')).resolves.toMatchObject({ status: 401 });
+			verify(mockedMessageService.createMessage(objectContaining(message))).never();
+		});
+
+		test('Forwards errors from MessageService', async () => {
+			const message = randomObject();
+			const authorization = randomString();
+			setGetUserAllowed(authorization, verifiedUser);
+			when(mockedMessageService.createMessage(objectContaining(message))).thenReject(testError400);
+
+			await expect(supertest(app).post('/api/v1/channels/id_placeholder/messages').send(message)
+				.set('Authorization', authorization)).resolves.toMatchObject({
+				status: 400,
+				body: {
+					error: testError400.message
+				}
+			});
+			verify(mockedMessageService.createMessage(objectContaining(message))).once();
+		});
+	});
+});

--- a/tests/unit/services/eventService.test.ts
+++ b/tests/unit/services/eventService.test.ts
@@ -2,7 +2,7 @@ import 'reflect-metadata';
 
 import EventService from '../../../src/services/EventService';
 import { createDBConnection } from '../../../src';
-import { Event } from '../../../src/entities/Event';
+import { Event, APIEvent } from '../../../src/entities/Event';
 import events from '../../fixtures/events';
 import { getConnection, getRepository } from 'typeorm';
 import '../../util/dbTeardown';
@@ -20,12 +20,17 @@ const eventService = new EventService();
 
 describe('EventService', () => {
 	describe('createEvent', () => {
-		const basePayload: Omit<Event, 'id'> = Object.assign({ ...events[0] }, { ...events[0], id: undefined });
+		const basePayload: Omit<APIEvent, 'id'> = Object.assign({ ...events[0] }, {
+			...events[0].toJSON(),
+			channel: undefined,
+			id: undefined
+		});
 
-		test('Registers a user with valid details', async () => {
+		test('Creates an event with valid details', async () => {
 			const event = await eventService.createEvent(basePayload);
-			expect({ ...basePayload, id: event.id }).toEqual(event);
-			await expect(getRepository(Event).findOne(event.id)).resolves.toEqual(event);
+			expect({ ...basePayload, id: event.id, channelID: event.channelID }).toEqual(event);
+			const repoEvent = await getRepository(Event).findOneOrFail(event.id);
+			expect(repoEvent.toJSON()).toEqual(event);
 		});
 
 		test('Throws when title too long', async () => {
@@ -49,23 +54,23 @@ describe('EventService', () => {
 		test('Returns singleton list for 1 event', async () => {
 			const savedEvents = [events[0]];
 			await getRepository(Event).save(savedEvents);
-			await (expect(eventService.findAll())).resolves.toEqual(savedEvents);
+			await (expect(eventService.findAll())).resolves.toEqual(savedEvents.map(event => event.toJSON()));
 		});
 
 		test('Returns 2 events when there are 2 events', async () => {
 			const savedEvents = [events[0], events[1]];
 			await getRepository(Event).save(savedEvents);
-			await (expect(eventService.findAll())).resolves.toEqual(savedEvents);
+			await (expect(eventService.findAll())).resolves.toEqual(savedEvents.map(event => event.toJSON()));
 		});
 
 		test('Updates whenever events list is updated', async () => {
 			await (expect(eventService.findAll())).resolves.toEqual([]);
 			await getRepository(Event).save(events[0]);
-			await (expect(eventService.findAll())).resolves.toEqual([events[0]]);
+			await (expect(eventService.findAll())).resolves.toEqual([events[0]].map(event => event.toJSON()));
 			await getRepository(Event).save(events[1]);
-			await (expect(eventService.findAll())).resolves.toEqual([events[0], events[1]]);
+			await (expect(eventService.findAll())).resolves.toEqual([events[0], events[1]].map(event => event.toJSON()));
 			await getRepository(Event).remove(events[0]);
-			await (expect(eventService.findAll())).resolves.toEqual([events[1]]);
+			await (expect(eventService.findAll())).resolves.toEqual([events[1]].map(event => event.toJSON()));
 		});
 	});
 
@@ -76,7 +81,7 @@ describe('EventService', () => {
 				id: event.id,
 				title: 'Test123'
 			});
-			expect({ ...event, title: 'Test123' }).toEqual(await getRepository(Event).findOneOrFail(events[0].id));
+			expect({ ...event.toJSON(), title: 'Test123' }).toEqual((await getRepository(Event).findOneOrFail(events[0].id)).toJSON());
 		});
 
 		test('Multiple edits are persisted', async () => {
@@ -85,13 +90,13 @@ describe('EventService', () => {
 				id: event.id,
 				title: 'Test123'
 			});
-			expect({ ...event, title: 'Test123' }).toEqual(await getRepository(Event).findOneOrFail(events[0].id));
+			expect({ ...event.toJSON(), title: 'Test123' }).toEqual((await getRepository(Event).findOneOrFail(events[0].id)).toJSON());
 			await eventService.editEvent({
 				id: event.id,
 				title: 'Testing title',
 				description: 'New description!'
 			});
-			expect({ ...event, title: 'Testing title', description: 'New description!' }).toEqual(await getRepository(Event).findOneOrFail(events[0].id));
+			expect({ ...event.toJSON(), title: 'Testing title', description: 'New description!' }).toEqual((await getRepository(Event).findOneOrFail(events[0].id)).toJSON());
 		});
 
 		test('Fails on invalid id/event not found', async () => {
@@ -104,7 +109,7 @@ describe('EventService', () => {
 		test('Fails for invalid data (title too long)', async () => {
 			const event = await getRepository(Event).save(events[0]);
 			await expect(eventService.editEvent({ id: event.id, title: 'Test123'.repeat(50) })).rejects.toMatchObject({ httpCode: 400 });
-			await expect(eventService.findAll()).resolves.toEqual([event]);
+			await expect(eventService.findAll()).resolves.toEqual([event.toJSON()]);
 		});
 	});
 });

--- a/tests/unit/services/messageService.test.ts
+++ b/tests/unit/services/messageService.test.ts
@@ -1,0 +1,49 @@
+import 'reflect-metadata';
+
+import { createDBConnection } from '../../../src';
+import { getConnection, getRepository } from 'typeorm';
+import '../../util/dbTeardown';
+import MessageService from '../../../src/services/MessageService';
+import users from '../../fixtures/users';
+import events from '../../fixtures/events';
+import { createMessage } from '../../fixtures/messages';
+import { AccountStatus, User } from '../../../src/entities/User';
+import { Channel } from '../../../src/entities/Channel';
+
+beforeAll(async () => {
+	await createDBConnection();
+});
+
+afterEach(async () => {
+	await getConnection().dropDatabase();
+	await getConnection().synchronize();
+});
+
+const messageService = new MessageService();
+
+describe('EventService', () => {
+	const author = users.find(user => user.accountStatus === AccountStatus.Verified)!;
+	const channel = events[0].channel;
+
+	beforeEach(async () => {
+		await getRepository(User).save(author);
+		await getRepository(Channel).save(channel);
+	});
+
+	describe('createEvent', () => {
+		const [basePayload, baseAPIMessage] = createMessage({ author, channel });
+
+		test('Creates an event with valid data', async () => {
+			const createdMessage = await messageService.createMessage(basePayload);
+			expect({ ...createdMessage, id: baseAPIMessage.id }).toEqual(baseAPIMessage);
+		});
+
+		test('Throws when invalid data passed', async () => {
+			await expect(messageService.createMessage({ ...basePayload, content: '' })).rejects.toMatchObject({ httpCode: 400 });
+			await expect(messageService.createMessage({ ...basePayload, time: '' })).rejects.toMatchObject({ httpCode: 400 });
+			// The following 2 outcomes would be unexpected in production
+			await expect(messageService.createMessage({ ...basePayload, authorID: '' })).rejects.toThrow();
+			await expect(messageService.createMessage({ ...basePayload, channelID: '' })).rejects.toThrow();
+		});
+	});
+});

--- a/tests/unit/services/messageService.test.ts
+++ b/tests/unit/services/messageService.test.ts
@@ -64,10 +64,8 @@ describe('EventService', () => {
 		});
 
 		test('Fails for unknown message', async () => {
-			await expect(messageService.getMessage({
-				channelID: baseMessage.channel.id,
-				id: 'fakeid'
-			})).rejects.toMatchObject({ httpCode: 404 });
+			await expect(messageService.getMessage({ channelID: baseMessage.channel.id, id: 'fakeid' })).rejects.toMatchObject({ httpCode: 404 });
+			await expect(messageService.getMessage({ channelID: baseMessage.channel.id, id: '' })).rejects.toMatchObject({ httpCode: 404 });
 		});
 
 		test('Fails for channel mismatch', async () => {
@@ -125,10 +123,8 @@ describe('EventService', () => {
 		});
 
 		test('Fails for unknown message (admin)', async () => {
-			await expect(messageService.deleteMessage({
-				channelID: baseMessage.channel.id,
-				id: 'fakeid'
-			})).rejects.toMatchObject({ httpCode: 404 });
+			await expect(messageService.deleteMessage({ channelID: baseMessage.channel.id, id: 'fakeid' })).rejects.toMatchObject({ httpCode: 404 });
+			await expect(messageService.deleteMessage({ channelID: baseMessage.channel.id, id: '' })).rejects.toMatchObject({ httpCode: 404 });
 		});
 
 		test('Fails for channel mismatch (admin)', async () => {
@@ -152,6 +148,12 @@ describe('EventService', () => {
 				id: 'fakeid',
 				authorID: author.id
 			})).rejects.toMatchObject({ httpCode: 404 });
+
+			await expect(messageService.deleteMessage({
+				channelID: baseMessage.channel.id,
+				id: '',
+				authorID: author.id
+			})).rejects.toMatchObject({ httpCode: 404 });
 		});
 
 		test('Fails for channel mismatch (user)', async () => {
@@ -164,7 +166,7 @@ describe('EventService', () => {
 
 		test('Fails when user is not author', async () => {
 			await expect(messageService.deleteMessage({
-				channelID: 'fakeid',
+				channelID: baseMessage.channel.id,
 				id: baseMessage.id,
 				authorID: 'fakeuserid'
 			})).rejects.toMatchObject({ httpCode: 400 });

--- a/tests/unit/services/messageService.test.ts
+++ b/tests/unit/services/messageService.test.ts
@@ -48,7 +48,6 @@ describe('EventService', () => {
 		});
 	});
 
-
 	describe('getMessage', () => {
 		const [, baseMessage] = createMessage({ author, channel });
 
@@ -75,6 +74,68 @@ describe('EventService', () => {
 			await expect(messageService.getMessage({
 				channelID: 'fakechannelid',
 				id: baseMessage.id
+			})).rejects.toMatchObject({ httpCode: 400 });
+		});
+	});
+
+
+	describe('deleteMessage', () => {
+		const [, baseMessage] = createMessage({ author, channel });
+
+		beforeEach(async () => {
+			await getRepository(Message).save(baseMessage);
+		});
+
+		test('Deletes message with valid data (admin)', async () => {
+			await expect(messageService.deleteMessage({
+				channelID: baseMessage.channel.id,
+				id: baseMessage.id
+			})).resolves.not.toThrow();
+		});
+
+		test('Fails for unknown message (admin)', async () => {
+			await expect(messageService.deleteMessage({
+				channelID: baseMessage.channel.id,
+				id: 'fakeid'
+			})).rejects.toMatchObject({ httpCode: 404 });
+		});
+
+		test('Fails for channel mismatch (admin)', async () => {
+			await expect(messageService.deleteMessage({
+				channelID: 'fakeid',
+				id: baseMessage.id
+			})).rejects.toMatchObject({ httpCode: 400 });
+		});
+
+		test('Deletes message with valid data (user)', async () => {
+			await expect(messageService.deleteMessage({
+				channelID: baseMessage.channel.id,
+				id: baseMessage.id,
+				authorID: author.id
+			})).resolves.not.toThrow();
+		});
+
+		test('Fails for unknown message (user)', async () => {
+			await expect(messageService.deleteMessage({
+				channelID: baseMessage.channel.id,
+				id: 'fakeid',
+				authorID: author.id
+			})).rejects.toMatchObject({ httpCode: 404 });
+		});
+
+		test('Fails for channel mismatch (user)', async () => {
+			await expect(messageService.deleteMessage({
+				channelID: 'fakeid',
+				id: baseMessage.id,
+				authorID: author.id
+			})).rejects.toMatchObject({ httpCode: 400 });
+		});
+
+		test('Fails when user is not author', async () => {
+			await expect(messageService.deleteMessage({
+				channelID: 'fakeid',
+				id: baseMessage.id,
+				authorID: 'fakeuserid'
 			})).rejects.toMatchObject({ httpCode: 400 });
 		});
 	});

--- a/tests/unit/services/messageService.test.ts
+++ b/tests/unit/services/messageService.test.ts
@@ -10,6 +10,7 @@ import { createMessage } from '../../fixtures/messages';
 import { AccountStatus, User } from '../../../src/entities/User';
 import { Channel } from '../../../src/entities/Channel';
 import Message from '../../../src/entities/Message';
+import { HttpCode } from '../../../src/util/errors';
 
 beforeAll(async () => {
 	await createDBConnection();
@@ -40,8 +41,8 @@ describe('MessageService', () => {
 		});
 
 		test('Throws when invalid data passed', async () => {
-			await expect(messageService.createMessage({ ...basePayload, content: '' })).rejects.toMatchObject({ httpCode: 400 });
-			await expect(messageService.createMessage({ ...basePayload, time: '' })).rejects.toMatchObject({ httpCode: 400 });
+			await expect(messageService.createMessage({ ...basePayload, content: '' })).rejects.toMatchObject({ httpCode: HttpCode.BadRequest });
+			await expect(messageService.createMessage({ ...basePayload, time: '' })).rejects.toMatchObject({ httpCode: HttpCode.BadRequest });
 			// The following 2 outcomes would be unexpected in production
 			await expect(messageService.createMessage({ ...basePayload, authorID: '' })).rejects.toThrow();
 			await expect(messageService.createMessage({ ...basePayload, channelID: '' })).rejects.toThrow();
@@ -64,15 +65,15 @@ describe('MessageService', () => {
 		});
 
 		test('Fails for unknown message', async () => {
-			await expect(messageService.getMessage({ channelID: baseMessage.channel.id, id: 'fakeid' })).rejects.toMatchObject({ httpCode: 404 });
-			await expect(messageService.getMessage({ channelID: baseMessage.channel.id, id: '' })).rejects.toMatchObject({ httpCode: 404 });
+			await expect(messageService.getMessage({ channelID: baseMessage.channel.id, id: 'fakeid' })).rejects.toMatchObject({ httpCode: HttpCode.NotFound });
+			await expect(messageService.getMessage({ channelID: baseMessage.channel.id, id: '' })).rejects.toMatchObject({ httpCode: HttpCode.NotFound });
 		});
 
 		test('Fails for channel mismatch', async () => {
 			await expect(messageService.getMessage({
 				channelID: 'fakechannelid',
 				id: baseMessage.id
-			})).rejects.toMatchObject({ httpCode: 400 });
+			})).rejects.toMatchObject({ httpCode: HttpCode.BadRequest });
 		});
 	});
 
@@ -96,7 +97,7 @@ describe('MessageService', () => {
 				channelID: '',
 				count: 2,
 				page: 0
-			})).rejects.toMatchObject({ httpCode: 404 });
+			})).rejects.toMatchObject({ httpCode: HttpCode.NotFound });
 		});
 
 		test('Fails for unknown channel', async () => {
@@ -104,7 +105,7 @@ describe('MessageService', () => {
 				channelID: author.id,
 				count: 2,
 				page: 0
-			})).rejects.toMatchObject({ httpCode: 404 });
+			})).rejects.toMatchObject({ httpCode: HttpCode.NotFound });
 		});
 	});
 
@@ -123,15 +124,15 @@ describe('MessageService', () => {
 		});
 
 		test('Fails for unknown message (admin)', async () => {
-			await expect(messageService.deleteMessage({ channelID: baseMessage.channel.id, id: 'fakeid' })).rejects.toMatchObject({ httpCode: 404 });
-			await expect(messageService.deleteMessage({ channelID: baseMessage.channel.id, id: '' })).rejects.toMatchObject({ httpCode: 404 });
+			await expect(messageService.deleteMessage({ channelID: baseMessage.channel.id, id: 'fakeid' })).rejects.toMatchObject({ httpCode: HttpCode.NotFound });
+			await expect(messageService.deleteMessage({ channelID: baseMessage.channel.id, id: '' })).rejects.toMatchObject({ httpCode: HttpCode.NotFound });
 		});
 
 		test('Fails for channel mismatch (admin)', async () => {
 			await expect(messageService.deleteMessage({
 				channelID: 'fakeid',
 				id: baseMessage.id
-			})).rejects.toMatchObject({ httpCode: 400 });
+			})).rejects.toMatchObject({ httpCode: HttpCode.BadRequest });
 		});
 
 		test('Deletes message with valid data (user)', async () => {
@@ -147,13 +148,13 @@ describe('MessageService', () => {
 				channelID: baseMessage.channel.id,
 				id: 'fakeid',
 				authorID: author.id
-			})).rejects.toMatchObject({ httpCode: 404 });
+			})).rejects.toMatchObject({ httpCode: HttpCode.NotFound });
 
 			await expect(messageService.deleteMessage({
 				channelID: baseMessage.channel.id,
 				id: '',
 				authorID: author.id
-			})).rejects.toMatchObject({ httpCode: 404 });
+			})).rejects.toMatchObject({ httpCode: HttpCode.NotFound });
 		});
 
 		test('Fails for channel mismatch (user)', async () => {
@@ -161,7 +162,7 @@ describe('MessageService', () => {
 				channelID: 'fakeid',
 				id: baseMessage.id,
 				authorID: author.id
-			})).rejects.toMatchObject({ httpCode: 400 });
+			})).rejects.toMatchObject({ httpCode: HttpCode.BadRequest });
 		});
 
 		test('Fails when user is not author', async () => {
@@ -169,7 +170,7 @@ describe('MessageService', () => {
 				channelID: baseMessage.channel.id,
 				id: baseMessage.id,
 				authorID: 'fakeuserid'
-			})).rejects.toMatchObject({ httpCode: 400 });
+			})).rejects.toMatchObject({ httpCode: HttpCode.BadRequest });
 		});
 	});
 });

--- a/tests/unit/services/messageService.test.ts
+++ b/tests/unit/services/messageService.test.ts
@@ -9,6 +9,7 @@ import events from '../../fixtures/events';
 import { createMessage } from '../../fixtures/messages';
 import { AccountStatus, User } from '../../../src/entities/User';
 import { Channel } from '../../../src/entities/Channel';
+import Message from '../../../src/entities/Message';
 
 beforeAll(async () => {
 	await createDBConnection();
@@ -31,11 +32,11 @@ describe('EventService', () => {
 	});
 
 	describe('createEvent', () => {
-		const [basePayload, baseAPIMessage] = createMessage({ author, channel });
+		const [basePayload, baseMessage] = createMessage({ author, channel });
 
 		test('Creates an event with valid data', async () => {
 			const createdMessage = await messageService.createMessage(basePayload);
-			expect({ ...createdMessage, id: baseAPIMessage.id }).toEqual(baseAPIMessage);
+			expect({ ...createdMessage, id: baseMessage.id }).toEqual(baseMessage.toJSON());
 		});
 
 		test('Throws when invalid data passed', async () => {
@@ -44,6 +45,37 @@ describe('EventService', () => {
 			// The following 2 outcomes would be unexpected in production
 			await expect(messageService.createMessage({ ...basePayload, authorID: '' })).rejects.toThrow();
 			await expect(messageService.createMessage({ ...basePayload, channelID: '' })).rejects.toThrow();
+		});
+	});
+
+
+	describe('getMessage', () => {
+		const [, baseMessage] = createMessage({ author, channel });
+
+		beforeEach(async () => {
+			await getRepository(Message).save(baseMessage);
+		});
+
+		test('Finds message with valid data', async () => {
+			const receivedMessage = await messageService.getMessage({
+				channelID: baseMessage.channel.id,
+				id: baseMessage.id
+			});
+			expect(receivedMessage).toEqual(baseMessage.toJSON());
+		});
+
+		test('Fails for unknown message', async () => {
+			await expect(messageService.getMessage({
+				channelID: baseMessage.channel.id,
+				id: 'fakeid'
+			})).rejects.toMatchObject({ httpCode: 404 });
+		});
+
+		test('Fails for channel mismatch', async () => {
+			await expect(messageService.getMessage({
+				channelID: 'fakechannelid',
+				id: baseMessage.id
+			})).rejects.toMatchObject({ httpCode: 400 });
 		});
 	});
 });

--- a/tests/unit/services/messageService.test.ts
+++ b/tests/unit/services/messageService.test.ts
@@ -22,7 +22,7 @@ afterEach(async () => {
 
 const messageService = new MessageService();
 
-describe('EventService', () => {
+describe('MessageService', () => {
 	const author = users.find(user => user.accountStatus === AccountStatus.Verified)!;
 	const channel = events[0].channel;
 
@@ -31,10 +31,10 @@ describe('EventService', () => {
 		await getRepository(Channel).save(channel);
 	});
 
-	describe('createEvent', () => {
+	describe('createMessage', () => {
 		const [basePayload, baseMessage] = createMessage({ author, channel });
 
-		test('Creates an event with valid data', async () => {
+		test('Creates a message with valid data', async () => {
 			const createdMessage = await messageService.createMessage(basePayload);
 			expect({ ...createdMessage, id: baseMessage.id }).toEqual(baseMessage.toJSON());
 		});


### PR DESCRIPTION
- Adds the `Channel` and `EventChannel` entities. An EventChannel is the channel assigned to a public Event.
- Adds the `Message` entity

Things to address in the future:

- No gateway events are dispatched
- Pagination will not work under certain edge-cases. For example, if a message is deleted and the next page is fetched, the offset will be different and a message will be missed.