### PR TITLE
feat: gateway events for messages

### DIFF
--- a/src/controllers/GatewayController.ts
+++ b/src/controllers/GatewayController.ts
@@ -53,6 +53,15 @@ export default class GatewayController {
 		}
 	}
 
+	public async broadcast(message: GatewayPacket) {
+		await this.gatewayService.send([...this.authenticatedClients.keys()], message);
+	}
+
+	public async sendMessage(to: string[], message: GatewayPacket) {
+		const recipients = [...this.authenticatedClients.entries()].filter(([,id]) => to.includes(id)).map(entry => entry[0]);
+		await this.gatewayService.send(recipients, message);
+	}
+
 	public async onAuthenticate(ws: WebSocket, packet: IdentifyGatewayPacket) {
 		if (this.authenticatedClients.has(ws)) throw new GatewayError('Already authenticated!');
 		const { token } = packet.data;

--- a/src/controllers/GatewayController.ts
+++ b/src/controllers/GatewayController.ts
@@ -53,7 +53,7 @@ export default class GatewayController {
 		}
 	}
 
-	public async broadcast(message: GatewayPacket) {
+	public async broadcast<T extends GatewayPacket>(message: T) {
 		await this.gatewayService.send([...this.authenticatedClients.keys()], message);
 	}
 

--- a/src/controllers/GatewayController.ts
+++ b/src/controllers/GatewayController.ts
@@ -57,7 +57,7 @@ export default class GatewayController {
 		await this.gatewayService.send([...this.authenticatedClients.keys()], message);
 	}
 
-	public async sendMessage(to: string[], message: GatewayPacket) {
+	public async sendMessage<T extends GatewayPacket>(to: string[], message: T) {
 		const recipients = [...this.authenticatedClients.entries()].filter(([,id]) => to.includes(id)).map(entry => entry[0]);
 		await this.gatewayService.send(recipients, message);
 	}

--- a/src/controllers/MessageController.ts
+++ b/src/controllers/MessageController.ts
@@ -4,6 +4,7 @@ import { AuthenticatedResponse } from '../routes/middleware/getUser';
 import MessageService from '../services/MessageService';
 import { AccountType } from '../entities/User';
 import { HttpCode } from '../util/errors';
+import { ChannelResponse } from '../routes/middleware/getChannel';
 
 @injectable()
 export class MessageController {
@@ -13,9 +14,9 @@ export class MessageController {
 		this.messageService = messageService;
 	}
 
-	public async createMessage(req: Request & { params: { channelID: string } }, res: AuthenticatedResponse, next: NextFunction): Promise<void> {
+	public async createMessage(req: Request, res: ChannelResponse, next: NextFunction): Promise<void> {
 		try {
-			const message = await this.messageService.createMessage({ ...req.body, channelID: req.params.channelID, authorID: res.locals.user.id });
+			const message = await this.messageService.createMessage({ ...req.body, channel: res.locals.channel, author: res.locals.user });
 			res.json({ message });
 		} catch (error) {
 			next(error);

--- a/src/controllers/MessageController.ts
+++ b/src/controllers/MessageController.ts
@@ -45,10 +45,10 @@ export class MessageController {
 		}
 	}
 
-	public async getMessages(req: Request & { params: { channelID: string; page: number } }, res: AuthenticatedResponse, next: NextFunction): Promise<void> {
+	public async getMessages(req: Request & { params: { channelID: string; page: number } }, res: ChannelResponse, next: NextFunction): Promise<void> {
 		try {
 			const messages = await this.messageService.getMessages({
-				channelID: req.params.channelID,
+				channel: res.locals.channel,
 				page: Number(req.query.page),
 				count: 50
 			});

--- a/src/routes/MessageRoutes.ts
+++ b/src/routes/MessageRoutes.ts
@@ -16,6 +16,6 @@ export class MessageRoutes {
 		router.post('/channels/:channelID/messages', getUser, isVerified, getChannel, this.messageController.createMessage.bind(this.messageController));
 		router.get('/channels/:channelID/messages', getUser, isVerified, this.messageController.getMessages.bind(this.messageController));
 		router.get('/channels/:channelID/messages/:messageID', getUser, isVerified, this.messageController.getMessage.bind(this.messageController));
-		router.delete('/channels/:channelID/messages/:messageID', getUser, isVerified, this.messageController.deleteMessage.bind(this.messageController));
+		router.delete('/channels/:channelID/messages/:messageID', getUser, isVerified, getChannel, this.messageController.deleteMessage.bind(this.messageController));
 	}
 }

--- a/src/routes/MessageRoutes.ts
+++ b/src/routes/MessageRoutes.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { inject, injectable } from 'tsyringe';
 import { getUser, isVerified } from './middleware';
 import { MessageController } from '../controllers/MessageController';
+import getChannel from './middleware/getChannel';
 
 @injectable()
 export class MessageRoutes {
@@ -12,7 +13,7 @@ export class MessageRoutes {
 	}
 
 	public routes(router: Router): void {
-		router.post('/channels/:channelID/messages', getUser, isVerified, this.messageController.createMessage.bind(this.messageController));
+		router.post('/channels/:channelID/messages', getUser, isVerified, getChannel, this.messageController.createMessage.bind(this.messageController));
 		router.get('/channels/:channelID/messages', getUser, isVerified, this.messageController.getMessages.bind(this.messageController));
 		router.get('/channels/:channelID/messages/:messageID', getUser, isVerified, this.messageController.getMessage.bind(this.messageController));
 		router.delete('/channels/:channelID/messages/:messageID', getUser, isVerified, this.messageController.deleteMessage.bind(this.messageController));

--- a/src/routes/MessageRoutes.ts
+++ b/src/routes/MessageRoutes.ts
@@ -14,7 +14,7 @@ export class MessageRoutes {
 
 	public routes(router: Router): void {
 		router.post('/channels/:channelID/messages', getUser, isVerified, getChannel, this.messageController.createMessage.bind(this.messageController));
-		router.get('/channels/:channelID/messages', getUser, isVerified, this.messageController.getMessages.bind(this.messageController));
+		router.get('/channels/:channelID/messages', getUser, isVerified, getChannel, this.messageController.getMessages.bind(this.messageController));
 		router.get('/channels/:channelID/messages/:messageID', getUser, isVerified, this.messageController.getMessage.bind(this.messageController));
 		router.delete('/channels/:channelID/messages/:messageID', getUser, isVerified, getChannel, this.messageController.deleteMessage.bind(this.messageController));
 	}

--- a/src/routes/middleware/getChannel.ts
+++ b/src/routes/middleware/getChannel.ts
@@ -1,0 +1,24 @@
+import { NextFunction, Request } from 'express';
+import { Channel, EventChannel } from '../../entities/Channel';
+import { APIError, HttpCode } from '../../util/errors';
+import { AuthenticatedResponse } from './getUser';
+import { container } from 'tsyringe';
+import ChannelService from '../../services/ChannelService';
+
+enum GetChannelError {
+	NotAllowed = 'You are not allowed to view this channel',
+	NotFound = 'Channel not found'
+}
+
+export type ChannelResponse = AuthenticatedResponse & { locals: { channel: Channel } };
+
+export default async function getChannel(req: Request, res: AuthenticatedResponse, next: NextFunction) {
+	const channelService = container.resolve(ChannelService);
+	const channel = await channelService.findOne({ id: req.params.channelID });
+	if (!channel) throw new APIError(HttpCode.NotFound, GetChannelError.NotFound);
+
+	if (channel instanceof EventChannel) {
+		(res as ChannelResponse).locals.channel = channel;
+	}
+	next();
+}

--- a/src/routes/middleware/getChannel.ts
+++ b/src/routes/middleware/getChannel.ts
@@ -14,8 +14,9 @@ export type ChannelResponse = AuthenticatedResponse & { locals: { channel: Chann
 
 export default async function getChannel(req: Request, res: AuthenticatedResponse, next: NextFunction) {
 	const channelService = container.resolve(ChannelService);
+	if (!req.params.channelID) return next(new APIError(HttpCode.NotFound, GetChannelError.NotFound));
 	const channel = await channelService.findOne({ id: req.params.channelID });
-	if (!channel) throw new APIError(HttpCode.NotFound, GetChannelError.NotFound);
+	if (!channel) return next(new APIError(HttpCode.NotFound, GetChannelError.NotFound));
 
 	if (channel instanceof EventChannel) {
 		(res as ChannelResponse).locals.channel = channel;

--- a/src/routes/middleware/index.ts
+++ b/src/routes/middleware/index.ts
@@ -1,3 +1,4 @@
 export { default as getUser } from './getUser';
 export { default as isVerified } from './isVerified';
 export { default as isAdmin } from './isAdmin';
+export { default as getChannel } from './getChannel';

--- a/src/services/ChannelService.ts
+++ b/src/services/ChannelService.ts
@@ -1,0 +1,10 @@
+import { singleton } from 'tsyringe';
+import { getRepository, FindOneOptions, FindConditions } from 'typeorm';
+import { Channel } from '../entities/Channel';
+
+@singleton()
+export default class ChannelService {
+	public async findOne(findConditions: FindConditions<Channel>, options?: FindOneOptions) {
+		return getRepository(Channel).findOne(findConditions, options);
+	}
+}

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -4,8 +4,9 @@ import { getRepository } from 'typeorm';
 import { APIError, formatValidationErrors, HttpCode } from '../util/errors';
 import { validateOrReject } from 'class-validator';
 import { Channel } from '../entities/Channel';
+import { User } from '../entities/User';
 
-type MessageCreationData = Omit<APIMessage, 'id'>;
+type MessageCreationData = Omit<APIMessage, 'id' | 'channelID' | 'authorID'> & { channel: Channel; author: User };
 
 enum GetMessageError {
 	NotFound = 'Message not found',
@@ -28,8 +29,8 @@ export default class MessageService {
 		const message = new Message();
 		message.content = data.content;
 		message.time = new Date(data.time);
-		message.author = { id: data.authorID } as any;
-		message.channel = { id: data.channelID } as any;
+		message.author = data.author;
+		message.channel = data.channel;
 		await validateOrReject(message).catch(e => Promise.reject(formatValidationErrors(e)));
 		return (await getRepository(Message).save(message)).toJSON();
 	}

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -19,10 +19,6 @@ enum DeleteMessageError {
 	NotAuthor = 'You are not the author of this message'
 }
 
-enum GetMessagesError {
-	ChannelNotFound = 'Channel does not exist'
-}
-
 @singleton()
 export default class MessageService {
 	public async createMessage(data: MessageCreationData): Promise<APIMessage> {
@@ -42,13 +38,11 @@ export default class MessageService {
 		return message.toJSON();
 	}
 
-	public async getMessages(data: { channelID: string; page?: number; count: number }): Promise<APIMessage[]> {
+	public async getMessages(data: { channel: Channel; page?: number; count: number }): Promise<APIMessage[]> {
 		if (!data.page || isNaN(data.page)) data.page = 0;
-		if (!data.channelID) throw new APIError(HttpCode.NotFound, GetMessagesError.ChannelNotFound);
-		const channel = await getRepository(Channel).findOneOrFail(data.channelID).catch(() => Promise.reject(new APIError(HttpCode.NotFound, GetMessagesError.ChannelNotFound)));
 		const messages = await getRepository(Message)
 			.find({
-				where: { channel },
+				where: { channel: data.channel },
 				order: { time: 'DESC' },
 				skip: data.count * data.page,
 				take: data.count

--- a/src/util/gateway/index.ts
+++ b/src/util/gateway/index.ts
@@ -1,8 +1,12 @@
+import { APIMessage } from '../../entities/Message';
+
 export class GatewayError extends Error {}
 
 export enum GatewayPacketType {
 	Identify = 'IDENTIFY',
-	Hello = 'HELLO'
+	Hello = 'HELLO',
+	MessageCreate = 'MESSAGE_CREATE',
+	MessageDelete = 'MESSAGE_DELETE'
 }
 
 export interface GatewayPacket {
@@ -18,4 +22,19 @@ export interface IdentifyGatewayPacket extends GatewayPacket {
 
 export interface HelloGatewayPacket extends GatewayPacket {
 	type: GatewayPacketType.Hello;
+}
+
+export interface MessageCreateGatewayPacket extends GatewayPacket {
+	type: GatewayPacketType.MessageCreate;
+	data: {
+		message: APIMessage;
+	};
+}
+
+export interface MessageDeleteGatewayPacket extends GatewayPacket {
+	type: GatewayPacketType.MessageDelete;
+	data: {
+		messageID: string;
+		channelID: string;
+	};
 }

--- a/tests/fixtures/messages.ts
+++ b/tests/fixtures/messages.ts
@@ -6,7 +6,7 @@ import users from './users';
 import events from './events';
 import { v4 as uuidv4 } from 'uuid';
 
-export function createMessage(data: { author?: User; channel?: Channel; content?: string; time?: Date }): [Pick<APIMessage, 'content' | 'authorID' | 'channelID' | 'time'>, Message] {
+export function createMessage(data: { author?: User; channel?: Channel; content?: string; time?: Date }): [Pick<APIMessage, 'content' | 'time'> & { author: User; channel: Channel }, Message] {
 	const concreteData = {
 		author: data.author ?? users.find(user => user.accountStatus === AccountStatus.Verified)!,
 		channel: data.channel ?? events[0].channel,
@@ -25,8 +25,8 @@ export function createMessage(data: { author?: User; channel?: Channel; content?
 	*/
 	return [
 		{
-			authorID: concreteData.author.id,
-			channelID: concreteData.channel.id,
+			author: concreteData.author,
+			channel: concreteData.channel,
 			content: concreteData.content,
 			time: message.time.toISOString()
 		},

--- a/tests/integration/controllers/messageController.test.ts
+++ b/tests/integration/controllers/messageController.test.ts
@@ -168,46 +168,46 @@ describe('MessageController', () => {
 
 	describe('getMessages', () => {
 		test('Ok response for valid request', async () => {
-			const channelID = eventChannel.id;
+			const channel = eventChannel;
 			const messages = [randomObject(), randomObject()];
 
 			const authorization = randomString();
 			setGetUserAllowed(authorization, verifiedUser);
-			when(mockedMessageService.getMessages(objectContaining({ channelID }))).thenResolve(messages);
-			const res = await supertest(app).get(`/api/v1/channels/${channelID}/messages`).set('Authorization', authorization);
+			when(mockedMessageService.getMessages(objectContaining({ channel }))).thenResolve(messages);
+			const res = await supertest(app).get(`/api/v1/channels/${channel.id}/messages`).set('Authorization', authorization);
 			expect(res.body).toEqual({ messages });
 			expect(res.status).toEqual(HttpCode.Ok);
-			verify(mockedMessageService.getMessages(objectContaining({ channelID }))).once();
+			verify(mockedMessageService.getMessages(objectContaining({ channel }))).once();
 		});
 
 		test('Unauthorized response for missing/invalid authorization', async () => {
-			const channelID = eventChannel.id;
+			const channel = eventChannel;
 			const messages = [randomObject(), randomObject()];
 
 			const authorization = randomString();
 			setGetUserAllowed(authorization, verifiedUser);
-			when(mockedMessageService.getMessages(objectContaining({ channelID }))).thenResolve(messages);
+			when(mockedMessageService.getMessages(objectContaining({ channel }))).thenResolve(messages);
 
-			await expect(supertest(app).get(`/api/v1/channels/${channelID}/messages`)).resolves.toMatchObject({ status: HttpCode.Unauthorized });
-			await expect(supertest(app).get(`/api/v1/channels/${channelID}/messages`).set('Authorization', 'badauth')).resolves.toMatchObject({ status: HttpCode.Unauthorized });
-			verify(mockedMessageService.getMessages(objectContaining({ channelID }))).never();
+			await expect(supertest(app).get(`/api/v1/channels/${channel.id}/messages`)).resolves.toMatchObject({ status: HttpCode.Unauthorized });
+			await expect(supertest(app).get(`/api/v1/channels/${channel.id}/messages`).set('Authorization', 'badauth')).resolves.toMatchObject({ status: HttpCode.Unauthorized });
+			verify(mockedMessageService.getMessages(objectContaining({ channel }))).never();
 		});
 
 		test('Forwards errors from MessageService', async () => {
-			const channelID = eventChannel.id;
+			const channel = eventChannel;
 
 			const authorization = randomString();
 			setGetUserAllowed(authorization, verifiedUser);
-			when(mockedMessageService.getMessages(objectContaining({ channelID }))).thenReject(testError400);
+			when(mockedMessageService.getMessages(objectContaining({ channel }))).thenReject(testError400);
 
-			await expect(supertest(app).get(`/api/v1/channels/${channelID}/messages`).set('Authorization', authorization))
+			await expect(supertest(app).get(`/api/v1/channels/${channel.id}/messages`).set('Authorization', authorization))
 				.resolves.toMatchObject({
 					status: HttpCode.BadRequest,
 					body: {
 						error: testError400.message
 					}
 				});
-			verify(mockedMessageService.getMessages(objectContaining({ channelID }))).once();
+			verify(mockedMessageService.getMessages(objectContaining({ channel }))).once();
 		});
 	});
 

--- a/tests/unit/middleware/getChannel.test.ts
+++ b/tests/unit/middleware/getChannel.test.ts
@@ -1,0 +1,55 @@
+import 'reflect-metadata';
+
+import { getChannel } from '../../../src/routes/middleware';
+import { container } from 'tsyringe';
+import { mock, instance, when, objectContaining, anything } from 'ts-mockito';
+import { AccountStatus } from '../../../src/entities/User';
+import ChannelService from '../../../src/services/ChannelService';
+import events from '../../fixtures/events';
+import users from '../../fixtures/users';
+import { APIError, HttpCode } from '../../../src/util/errors';
+
+const verifiedUserFixture = users.find(user => user.accountStatus === AccountStatus.Verified);
+
+const channelFixture = events[0].channel;
+let mockedChannelService: ChannelService;
+
+beforeAll(() => {
+	mockedChannelService = mock(ChannelService);
+	container.clearInstances();
+	container.register<ChannelService>(ChannelService, { useValue: instance(mockedChannelService) });
+
+	when(mockedChannelService.findOne(anything())).thenResolve(undefined);
+	when(mockedChannelService.findOne(objectContaining({ id: channelFixture.id }))).thenResolve(channelFixture);
+});
+
+describe('getChannel middleware', () => {
+	test('Resolves valid channel ID', async () => {
+		const req: any = { params: { channelID: channelFixture.id } };
+		const res: any = { locals: { user: verifiedUserFixture } };
+		const next: any = jest.fn();
+		await getChannel(req, res, next);
+		expect(res.locals.channel).toEqual(channelFixture);
+		expect(next).toHaveBeenCalledWith();
+	});
+
+	test('Throws when channel not found', async () => {
+		const req: any = { params: { channelID: 'a random id' } };
+		const res: any = { locals: { user: verifiedUserFixture } };
+		const next: any = jest.fn();
+		await getChannel(req, res, next);
+		expect(res.locals.channel).toBeUndefined();
+		expect(next.mock.calls[0][0]).toBeInstanceOf(APIError);
+		expect(next.mock.calls[0][0]).toMatchObject({ httpCode: HttpCode.NotFound });
+	});
+
+	test('Throws when no channel provided', async () => {
+		const req: any = { params: {} };
+		const res: any = { locals: { user: verifiedUserFixture } };
+		const next: any = jest.fn();
+		await getChannel(req, res, next);
+		expect(res.locals.channel).toBeUndefined();
+		expect(next.mock.calls[0][0]).toBeInstanceOf(APIError);
+		expect(next.mock.calls[0][0]).toMatchObject({ httpCode: HttpCode.NotFound });
+	});
+});

--- a/tests/unit/services/messageService.test.ts
+++ b/tests/unit/services/messageService.test.ts
@@ -84,25 +84,9 @@ describe('MessageService', () => {
 
 		test('Pagination works as expected', async () => {
 			for (let i = 0; i < 5; i++) {
-				const page = await messageService.getMessages({ channelID: channel.id, count: 2, page: i });
+				const page = await messageService.getMessages({ channel, count: 2, page: i });
 				expect(page).toEqual(baseMessages.slice(i * 2, (i + 1) * 2).map(m => m.toJSON()));
 			}
-		});
-
-		test('Fails for empty channel', async () => {
-			await expect(messageService.getMessages({
-				channelID: '',
-				count: 2,
-				page: 0
-			})).rejects.toMatchObject({ httpCode: HttpCode.NotFound });
-		});
-
-		test('Fails for unknown channel', async () => {
-			await expect(messageService.getMessages({
-				channelID: author.id,
-				count: 2,
-				page: 0
-			})).rejects.toMatchObject({ httpCode: HttpCode.NotFound });
 		});
 	});
 

--- a/tests/unit/services/messageService.test.ts
+++ b/tests/unit/services/messageService.test.ts
@@ -43,9 +43,6 @@ describe('MessageService', () => {
 		test('Throws when invalid data passed', async () => {
 			await expect(messageService.createMessage({ ...basePayload, content: '' })).rejects.toMatchObject({ httpCode: HttpCode.BadRequest });
 			await expect(messageService.createMessage({ ...basePayload, time: '' })).rejects.toMatchObject({ httpCode: HttpCode.BadRequest });
-			// The following 2 outcomes would be unexpected in production
-			await expect(messageService.createMessage({ ...basePayload, authorID: '' })).rejects.toThrow();
-			await expect(messageService.createMessage({ ...basePayload, channelID: '' })).rejects.toThrow();
 		});
 	});
 

--- a/tests/util/ws.ts
+++ b/tests/util/ws.ts
@@ -57,6 +57,7 @@ export class MockWebSocket extends EventEmitter implements WebSocket {
 	public CLOSED = WebSocket.CLOSED;
 	public mirror!: MockWebSocket;
 	public messages: string[];
+	public allMessages: string[];
 	private _nextMessagePromise?: [(data: string) => void, (error: Error) => void];
 	public onopen!: (event: WebSocket.OpenEvent) => void;
 	public onerror!: (event: WebSocket.ErrorEvent) => void;
@@ -71,8 +72,10 @@ export class MockWebSocket extends EventEmitter implements WebSocket {
 			setImmediate(() => this.mirror.emit('open'));
 		}
 		this.messages = [];
+		this.allMessages = [];
 		this.on('message', data => {
 			this.messages.push(data);
+			this.allMessages.push(data);
 			if (this._nextMessagePromise) {
 				this._nextMessagePromise[0](this.messages.shift()!);
 				this._nextMessagePromise = undefined;
@@ -117,6 +120,7 @@ export class MockWebSocket extends EventEmitter implements WebSocket {
 	}
 
 	public send(data: any, options?: any, cb?: (err: any) => void): Promise<void> {
+		if (typeof options === 'function') cb = options;
 		setImmediate(() => this.mirror.emit('message', data));
 		if (cb) cb(undefined);
 		return Promise.resolve();


### PR DESCRIPTION
Dispatches two new gateway events whenever a message is created/deleted:

```js
{
  "type": "MESSAGE_CREATE",
  "data": {
    "message": { /* ... */ } // message is of type APIMessage
  }
}
```

```js
{
  "type": "MESSAGE_DELETE",
  "data": {
    "messageID": "string",
    "channelID": "string"
  }
}
```

These events will only be broadcasted (dispatched to all users on the gateway) for event channels. For future channels, e.g. DM channels, the event will only be dispatched to those users.

---

This required a refactor of the internals involving a new middleware `getChannel`. This just loads the channel specified by its id in the route, so that the controller knows which users to dispatch the events to based on the channel type (EventChannels dispatched to everyone, other future channels will be different)