### PR TITLE
feat: implement discovery queue

### DIFF
--- a/src/controllers/GatewayController.ts
+++ b/src/controllers/GatewayController.ts
@@ -84,7 +84,12 @@ export default class GatewayController {
 	public async onJoinDiscoveryQueue(ws: WebSocket, packet: JoinDiscoveryQueuePacket) {
 		const userId = this.authenticatedClients.get(ws);
 		if (!userId) throw new GatewayError('Not authenticated');
-		const matchData = await this.discoveryQueue.addToQueue(userId, packet.data.options);
+		let matchData;
+		try {
+			matchData = await this.discoveryQueue.addToQueue(userId, packet.data.options);
+		} catch (error) {
+			throw new GatewayError(error.message);
+		}
 		if (matchData) {
 			const payload: DiscoveryQueueMatchPacket = {
 				type: GatewayPacketType.DiscoveryQueueMatch,

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -68,7 +68,7 @@ export class UserController {
 			const user = await this.userService.findOne({ id: req.params.id });
 			if (!user) throw new APIError(HttpCode.NotFound, GetUserError.UserNotFound);
 			res.json({
-				user: user.toLimitedJSON()
+				user: user.toJSON()
 			});
 		} catch (error) {
 			next(error);

--- a/src/entities/Profile.ts
+++ b/src/entities/Profile.ts
@@ -2,6 +2,16 @@ import { Entity, Column, OneToOne, PrimaryGeneratedColumn } from 'typeorm';
 import { IsString } from 'class-validator';
 import { User } from './User';
 
+export interface APIProfile {
+	id: string;
+	course: string;
+	yearOfStudy: number;
+	profilePicture?: string;
+	instagram?: string;
+	facebook?: string;
+	twitter?: string;
+}
+
 @Entity()
 export default class Profile {
 	@PrimaryGeneratedColumn('uuid')
@@ -29,9 +39,10 @@ export default class Profile {
 	@Column({ nullable: true })
 	public twitter?: string;
 
-	public toJSON() {
-		const { course, yearOfStudy, profilePicture, instagram, facebook, twitter } = this;
+	public toJSON(): APIProfile {
+		const { id, course, yearOfStudy, profilePicture, instagram, facebook, twitter } = this;
 		return {
+			id,
 			course,
 			yearOfStudy,
 			profilePicture,

--- a/src/entities/User.ts
+++ b/src/entities/User.ts
@@ -1,6 +1,6 @@
 import { Entity, PrimaryGeneratedColumn, Column, JoinColumn, OneToOne, ManyToMany, JoinTable } from 'typeorm';
 import { IsEmail, Matches, MinLength, MaxLength, IsString } from 'class-validator';
-import Profile from './Profile';
+import Profile, { APIProfile } from './Profile';
 import { DMChannel } from './Channel';
 
 export enum AccountStatus {
@@ -12,6 +12,19 @@ export enum AccountStatus {
 export enum AccountType {
 	User = 0,
 	Admin = 1
+}
+
+export interface APIUser {
+	id: string;
+	forename: string;
+	surname: string;
+	accountStatus: AccountStatus;
+	accountType: AccountType;
+	profile?: APIProfile;
+}
+
+export interface APIPrivateUser extends APIUser {
+	email: string;
 }
 
 @Entity()
@@ -53,13 +66,12 @@ export class User {
 	@JoinColumn()
 	public profile?: Profile;
 
-	public toJSON() {
-		const { id, forename, surname, email, accountStatus, accountType, profile } = this;
-		return { id, forename, surname, email, accountStatus, accountType, profile: profile?.toJSON() };
-	}
-
-	public toLimitedJSON() {
+	public toJSON(): APIUser {
 		const { id, forename, surname, accountStatus, accountType, profile } = this;
 		return { id, forename, surname, accountStatus, accountType, profile: profile?.toJSON() };
+	}
+
+	public toJSONPrivate(): APIPrivateUser {
+		return { ...this.toJSON(), email: this.email };
 	}
 }

--- a/src/util/discovery/DiscoveryQueue.ts
+++ b/src/util/discovery/DiscoveryQueue.ts
@@ -1,6 +1,6 @@
 import { UserService } from '../../services/UserService';
 import ChannelService from '../../services/ChannelService';
-import { inject, injectable } from 'tsyringe';
+import { inject, singleton } from 'tsyringe';
 import { APIDMChannel } from '../../entities/Channel';
 
 interface QueueUser {
@@ -20,7 +20,7 @@ interface QueueMatchData {
 	channel: APIDMChannel;
 }
 
-@injectable()
+@singleton()
 export class DiscoveryQueue {
 	private readonly userService: UserService;
 	private readonly channelService: ChannelService;
@@ -84,6 +84,14 @@ export class DiscoveryQueue {
 			// If neither user requires the same year, then match
 			} else {
 				return this.matchUsers(user.id, queueUser.user.id);
+			}
+		}
+	}
+
+	public removeFromQueue(userId: string): void {
+		for (const queueUser of this.queue.values()) {
+			if (queueUser.user.id === userId) {
+				this.queue.delete(queueUser);
 			}
 		}
 	}

--- a/src/util/discovery/DiscoveryQueue.ts
+++ b/src/util/discovery/DiscoveryQueue.ts
@@ -1,6 +1,6 @@
 import { UserService } from '../../services/UserService';
 import ChannelService from '../../services/ChannelService';
-import { container } from 'tsyringe';
+import { inject, injectable } from 'tsyringe';
 import { APIDMChannel } from '../../entities/Channel';
 
 interface QueueUser {
@@ -20,14 +20,15 @@ interface QueueMatchData {
 	channel: APIDMChannel;
 }
 
+@injectable()
 export class DiscoveryQueue {
 	private readonly userService: UserService;
 	private readonly channelService: ChannelService;
 	public readonly queue: Set<QueueUser>;
 
-	public constructor() {
-		this.userService = container.resolve<UserService>(UserService);
-		this.channelService = container.resolve<ChannelService>(ChannelService);
+	public constructor(@inject(UserService) userService: UserService, @inject(ChannelService) channelService: ChannelService) {
+		this.userService = userService;
+		this.channelService = channelService;
 		this.queue = new Set();
 	}
 

--- a/src/util/discovery/DiscoveryQueue.ts
+++ b/src/util/discovery/DiscoveryQueue.ts
@@ -1,0 +1,89 @@
+import { UserService } from '../../services/UserService';
+import ChannelService from '../../services/ChannelService';
+import { container } from 'tsyringe';
+import { APIDMChannel } from '../../entities/Channel';
+
+interface QueueUser {
+	user: {
+		id: string;
+		yearOfStudy: number;
+	};
+	options: QueueOptions;
+}
+
+interface QueueOptions {
+	sameYear: boolean;
+}
+
+interface QueueMatchData {
+	users: [string, string];
+	channel: APIDMChannel;
+}
+
+export class DiscoveryQueue {
+	private readonly userService: UserService;
+	private readonly channelService: ChannelService;
+	public readonly queue: Set<QueueUser>;
+
+	public constructor() {
+		this.userService = container.resolve<UserService>(UserService);
+		this.channelService = container.resolve<ChannelService>(ChannelService);
+		this.queue = new Set();
+	}
+
+	private async matchUsers(user1: string, user2: string): Promise<QueueMatchData> {
+		// Remove the members from the queue
+		for (const queueUser of this.queue.values()) {
+			if (queueUser.user.id === user1 || queueUser.user.id === user2) {
+				this.queue.delete(queueUser);
+			}
+		}
+
+		// Create the DM channel for the users
+		const dmChannel = await this.channelService.createOrGetDMChannel([user1, user2]);
+
+		return {
+			users: [user1, user2],
+			channel: dmChannel
+		};
+	}
+
+	/**
+	 * Adds a new user to the discovery queue and tries to pair them to someone
+	 * @param userId The user to add
+	 * @param options The options for matching
+	 * @returns the queue match data if a match was made
+	 */
+	public async addToQueue(userId: string, options: QueueOptions): Promise<QueueMatchData|undefined> {
+		for (const queueUser of this.queue.values()) {
+			if (queueUser.user.id === userId) {
+				continue;
+			}
+		}
+
+		const user = await this.userService.findOne({ id: userId }, { relations: ['dmChannels'] });
+		if (!user) throw new Error('User not found');
+		if (!user.profile) throw new Error('User profile is required');
+
+		// A list of DM channels that the user already has
+		const ineligibleIDs = user.dmChannels.map(channel => channel.users.map(user => user.id)).flat();
+
+		for (const queueUser of this.queue.values()) {
+			// If the potential user already has a dm channel with the new user, skip
+			if (ineligibleIDs.includes(queueUser.user.id)) {
+				continue;
+			}
+
+			// If either of the users require someone to be in the same year
+			if (queueUser.options.sameYear || options.sameYear) {
+				// Check that both users have the same year
+				if (queueUser.user.yearOfStudy === user.profile.yearOfStudy) {
+					return this.matchUsers(user.id, queueUser.user.id);
+				}
+			// If neither user requires the same year, then match
+			} else {
+				return this.matchUsers(user.id, queueUser.user.id);
+			}
+		}
+	}
+}

--- a/src/util/discovery/DiscoveryQueue.ts
+++ b/src/util/discovery/DiscoveryQueue.ts
@@ -11,7 +11,7 @@ interface QueueUser {
 	options: QueueOptions;
 }
 
-interface QueueOptions {
+export interface QueueOptions {
 	sameYear: boolean;
 }
 

--- a/src/util/discovery/DiscoveryQueue.ts
+++ b/src/util/discovery/DiscoveryQueue.ts
@@ -57,7 +57,7 @@ export class DiscoveryQueue {
 	public async addToQueue(userId: string, options: QueueOptions): Promise<QueueMatchData|undefined> {
 		for (const queueUser of this.queue.values()) {
 			if (queueUser.user.id === userId) {
-				continue;
+				return;
 			}
 		}
 

--- a/src/util/gateway/index.ts
+++ b/src/util/gateway/index.ts
@@ -1,4 +1,5 @@
 import { APIMessage } from '../../entities/Message';
+import { QueueOptions } from '../discovery/DiscoveryQueue';
 
 export class GatewayError extends Error {}
 
@@ -6,7 +7,15 @@ export enum GatewayPacketType {
 	Identify = 'IDENTIFY',
 	Hello = 'HELLO',
 	MessageCreate = 'MESSAGE_CREATE',
-	MessageDelete = 'MESSAGE_DELETE'
+	MessageDelete = 'MESSAGE_DELETE',
+	// Sent by the client to join a Discovery queue
+	JoinDiscoveryQueue = 'JOIN_DISCOVERY_QUEUE',
+	// Sent by the client to leave a Discovery queue
+	LeaveDiscoveryQueue = 'LEAVE_DISCOVERY_QUEUE',
+	// Sent by the gateway periodically to inform the client of how many users are in the queue
+	DiscoveryQueueUpdate = 'DISCOVERY_QUEUE_UPDATE',
+	// Sent by the gateway once a match has been made
+	DiscoveryQueueMatch = 'DISCOVERY_QUEUE_MATCH'
 }
 
 export interface GatewayPacket {
@@ -36,5 +45,35 @@ export interface MessageDeleteGatewayPacket extends GatewayPacket {
 	data: {
 		messageID: string;
 		channelID: string;
+	};
+}
+
+export interface JoinDiscoveryQueuePacket extends GatewayPacket {
+	type: GatewayPacketType.JoinDiscoveryQueue;
+	data: {
+		eventID: string;
+		options: QueueOptions;
+	};
+}
+
+export interface LeaveDiscoveryQueuePacket extends GatewayPacket {
+	type: GatewayPacketType.LeaveDiscoveryQueue;
+	data: {
+		eventID: string;
+	};
+}
+
+export interface DiscoveryQueueUpdatePacket extends GatewayPacket {
+	type: GatewayPacketType.DiscoveryQueueUpdate;
+	data: {
+		eventID: string;
+		queueLength: number;
+	};
+}
+
+export interface DiscoveryQueueMatchPacket extends GatewayPacket {
+	type: GatewayPacketType.DiscoveryQueueMatch;
+	data: {
+		// to-do :)
 	};
 }

--- a/src/util/gateway/index.ts
+++ b/src/util/gateway/index.ts
@@ -1,7 +1,6 @@
 import { APIMessage } from '../../entities/Message';
 import { QueueOptions } from '../discovery/DiscoveryQueue';
 import { APIDMChannel } from '../../entities/Channel';
-import { APIUser } from '../../entities/User';
 
 export class GatewayError extends Error {}
 
@@ -14,8 +13,6 @@ export enum GatewayPacketType {
 	JoinDiscoveryQueue = 'JOIN_DISCOVERY_QUEUE',
 	// Sent by the client to leave a Discovery queue
 	LeaveDiscoveryQueue = 'LEAVE_DISCOVERY_QUEUE',
-	// Sent by the gateway periodically to inform the client of how many users are in the queue
-	DiscoveryQueueUpdate = 'DISCOVERY_QUEUE_UPDATE',
 	// Sent by the gateway once a match has been made
 	DiscoveryQueueMatch = 'DISCOVERY_QUEUE_MATCH'
 }
@@ -53,30 +50,17 @@ export interface MessageDeleteGatewayPacket extends GatewayPacket {
 export interface JoinDiscoveryQueuePacket extends GatewayPacket {
 	type: GatewayPacketType.JoinDiscoveryQueue;
 	data: {
-		eventID: string;
 		options: QueueOptions;
 	};
 }
 
 export interface LeaveDiscoveryQueuePacket extends GatewayPacket {
 	type: GatewayPacketType.LeaveDiscoveryQueue;
-	data: {
-		eventID: string;
-	};
-}
-
-export interface DiscoveryQueueUpdatePacket extends GatewayPacket {
-	type: GatewayPacketType.DiscoveryQueueUpdate;
-	data: {
-		eventID: string;
-		queueLength: number;
-	};
 }
 
 export interface DiscoveryQueueMatchPacket extends GatewayPacket {
 	type: GatewayPacketType.DiscoveryQueueMatch;
 	data: {
 		channel: APIDMChannel;
-		user: APIUser;
 	};
 }

--- a/src/util/gateway/index.ts
+++ b/src/util/gateway/index.ts
@@ -1,6 +1,7 @@
 import { APIMessage } from '../../entities/Message';
 import { QueueOptions } from '../discovery/DiscoveryQueue';
 import { APIDMChannel } from '../../entities/Channel';
+import { APIUser } from '../../entities/User';
 
 export class GatewayError extends Error {}
 
@@ -76,5 +77,6 @@ export interface DiscoveryQueueMatchPacket extends GatewayPacket {
 	type: GatewayPacketType.DiscoveryQueueMatch;
 	data: {
 		channel: APIDMChannel;
+		user: APIUser;
 	};
 }

--- a/src/util/gateway/index.ts
+++ b/src/util/gateway/index.ts
@@ -1,5 +1,6 @@
 import { APIMessage } from '../../entities/Message';
 import { QueueOptions } from '../discovery/DiscoveryQueue';
+import { APIDMChannel } from '../../entities/Channel';
 
 export class GatewayError extends Error {}
 
@@ -74,6 +75,6 @@ export interface DiscoveryQueueUpdatePacket extends GatewayPacket {
 export interface DiscoveryQueueMatchPacket extends GatewayPacket {
 	type: GatewayPacketType.DiscoveryQueueMatch;
 	data: {
-		// to-do :)
+		channel: APIDMChannel;
 	};
 }

--- a/tests/integration/controllers/userController.test.ts
+++ b/tests/integration/controllers/userController.test.ts
@@ -180,7 +180,7 @@ describe('UserController', () => {
 
 			when(mockedUserService.findOne(objectContaining({ id: user!.id }))).thenResolve(user);
 			const res = await supertest(app).get(`/api/v1/users/@me`).set('Authorization', authorization);
-			expect(clean(res.body)).toEqual(clean({ user: user!.toLimitedJSON() }));
+			expect(clean(res.body)).toEqual(clean({ user: user!.toJSON() }));
 			expect(res.status).toEqual(HttpCode.Ok);
 		});
 
@@ -192,7 +192,7 @@ describe('UserController', () => {
 			when(mockedUserService.findOne(objectContaining({ id: userMe.id }))).thenResolve(userMe);
 			when(mockedUserService.findOne(objectContaining({ id: userOther.id }))).thenResolve(userOther);
 			const res = await supertest(app).get(`/api/v1/users/${userOther.id}`).set('Authorization', authorization);
-			expect(clean(res.body)).toEqual(clean({ user: userOther.toLimitedJSON() }));
+			expect(clean(res.body)).toEqual(clean({ user: userOther.toJSON() }));
 			expect(res.status).toEqual(HttpCode.Ok);
 		});
 
@@ -218,7 +218,7 @@ describe('UserController', () => {
 			when(mockedUserService.findOne(objectContaining({ id: userOther!.id }))).thenResolve(userOther);
 			const res = await supertest(app).get(`/api/v1/users/${userOther!.id}`).set('Authorization', authorization);
 			expect(res.status).toEqual(HttpCode.Ok);
-			expect(clean(res.body)).toEqual(clean({ user: userOther!.toLimitedJSON() }));
+			expect(clean(res.body)).toEqual(clean({ user: userOther!.toJSON() }));
 		});
 
 		test('Not found error when user does not exist', async () => {

--- a/tests/unit/services/userService.test.ts
+++ b/tests/unit/services/userService.test.ts
@@ -6,7 +6,7 @@ import users from '../../fixtures/users';
 import * as passwordUtils from '../../../src/util/password';
 import { getConnection, getRepository } from 'typeorm';
 import { EmailConfirmation } from '../../../src/entities/EmailConfirmation';
-import Profile from '../../../src/entities/Profile';
+import { APIProfile } from '../../../src/entities/Profile';
 import { HttpCode } from '../../../src/util/errors';
 
 beforeAll(async () => {
@@ -144,7 +144,7 @@ describe('UserService', () => {
 
 		test('Authenticates a user with the correct password', async () => {
 			const resolvedUser = await userService.authenticate(user.email, 'thunderbolt');
-			expect(resolvedUser).toMatchObject(user);
+			expect(resolvedUser).toMatchObject(user.toJSONPrivate());
 		});
 
 		test('Authenticate fails with empty/invalid email', async () => {
@@ -171,9 +171,9 @@ describe('UserService', () => {
 				course: 'Computer Science',
 				yearOfStudy: 1
 			});
-			expect(savedUser).toMatchObject(userWithoutProfile);
-			const nonNullishProperties = [...Object.keys(savedUser.profile!)].filter(prop => savedUser.profile![prop as keyof Profile]);
-			expect(nonNullishProperties).toEqual(expect.arrayContaining(['id', 'course', 'yearOfStudy', 'user']));
+			expect({ ...savedUser, profile: undefined }).toMatchObject(userWithoutProfile.toJSONPrivate());
+			const nonNullishProperties = [...Object.keys(savedUser.profile!)].filter(prop => savedUser.profile![prop as keyof APIProfile]);
+			expect(nonNullishProperties).toEqual(expect.arrayContaining(['id', 'course', 'yearOfStudy']));
 			expect(savedUser.profile!.course).toStrictEqual('Computer Science');
 			expect(savedUser.profile!.yearOfStudy).toStrictEqual(1);
 		});
@@ -185,8 +185,8 @@ describe('UserService', () => {
 				yearOfStudy: 2
 			});
 			expect(userWithProfile).toMatchObject({ ...savedUser, profile: userWithProfile.profile });
-			const nonNullishProperties = [...Object.keys(savedUser.profile!)].filter(prop => savedUser.profile![prop as keyof Profile]);
-			expect(nonNullishProperties).toEqual(expect.arrayContaining(['id', 'course', 'yearOfStudy', 'user']));
+			const nonNullishProperties = [...Object.keys(savedUser.profile!)].filter(prop => savedUser.profile![prop as keyof APIProfile]);
+			expect(nonNullishProperties).toEqual(expect.arrayContaining(['id', 'course', 'yearOfStudy']));
 			expect(initialProfile).not.toMatchObject(savedUser.profile!);
 			expect(savedUser.profile!.course).toStrictEqual('Software Engineering');
 			expect(savedUser.profile!.yearOfStudy).toStrictEqual(2);


### PR DESCRIPTION
This PR implements a discovery queue used for the 1:1 networking.

- Users join the Discovery Queue via the gateway, supplying some "matching" options (currently only whether to match with users in the same year, can be extended)
- When a user joins the queue, we check to see if the user could be paired with someone else in the queue. If so, we create a DM channel for them and pair them up, sending them both a gateway event with the created DM channel.
- A user can also leave the Discovery Queue via the gateway also.

Again, this PR is lacking in any tests but I would like to get as many features done as I can for peace of mind before beginning to write the tests due to time constraints :sweat_smile: 