### PR TITLE
feat(channels): order channels by last modified timestamp in /channels endpoint

### DIFF
--- a/src/controllers/MessageController.ts
+++ b/src/controllers/MessageController.ts
@@ -21,7 +21,7 @@ export class MessageController {
 
 	public async createMessage(req: Request, res: ChannelResponse, next: NextFunction): Promise<void> {
 		try {
-			const message = await this.messageService.createMessage({ ...req.body, channel: res.locals.channel, author: res.locals.user });
+			const message = await this.messageService.createMessage({ ...req.body, channel: res.locals.channel, author: res.locals.user, time: new Date() });
 			const gatewayPayload: MessageCreateGatewayPacket = {
 				type: GatewayPacketType.MessageCreate,
 				data: {

--- a/src/entities/Channel.ts
+++ b/src/entities/Channel.ts
@@ -1,9 +1,11 @@
-import { PrimaryGeneratedColumn, OneToOne, Entity, TableInheritance, ChildEntity, ManyToMany } from 'typeorm';
+import { PrimaryGeneratedColumn, OneToOne, Entity, TableInheritance, ChildEntity, ManyToMany, Column } from 'typeorm';
 import { Event, APIEvent } from './Event';
 import { User } from './User';
+import { IsDate } from 'class-validator';
 
 export interface APIChannel {
 	id: string;
+	lastUpdated: string;
 }
 
 export interface APIEventChannel extends APIChannel {
@@ -22,9 +24,14 @@ export class Channel {
 	@PrimaryGeneratedColumn('uuid')
 	public id!: string;
 
+	@Column('timestamp', { 'default': () => 'CURRENT_TIMESTAMP' })
+	@IsDate()
+	public lastUpdated!: Date;
+
 	public toJSON(): APIChannel {
 		return {
-			id: this.id
+			id: this.id,
+			lastUpdated: this.lastUpdated.toISOString()
 		};
 	}
 }

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -1,6 +1,6 @@
 import { singleton } from 'tsyringe';
 import Message, { APIMessage } from '../entities/Message';
-import { getRepository } from 'typeorm';
+import { getRepository, getConnection } from 'typeorm';
 import { APIError, formatValidationErrors, HttpCode } from '../util/errors';
 import { validateOrReject } from 'class-validator';
 import { Channel } from '../entities/Channel';
@@ -21,14 +21,18 @@ enum DeleteMessageError {
 
 @singleton()
 export default class MessageService {
-	public async createMessage(data: MessageCreationData): Promise<APIMessage> {
-		const message = new Message();
-		message.content = data.content;
-		message.time = new Date(data.time);
-		message.author = data.author;
-		message.channel = data.channel;
-		await validateOrReject(message).catch(e => Promise.reject(formatValidationErrors(e)));
-		return (await getRepository(Message).save(message)).toJSON();
+	public createMessage(data: MessageCreationData): Promise<APIMessage> {
+		return getConnection().transaction(async entityManager => {
+			const message = new Message();
+			message.content = data.content;
+			message.time = new Date(data.time);
+			message.author = data.author;
+			message.channel = data.channel;
+			await validateOrReject(message).catch(e => Promise.reject(formatValidationErrors(e)));
+			const savedMessage = await entityManager.save(message);
+			await entityManager.update(Channel, data.channel.id, { lastUpdated: message.time });
+			return savedMessage.toJSON();
+		});
 	}
 
 	public async getMessage(data: Pick<APIMessage, 'id' | 'channelID'>): Promise<APIMessage> {
@@ -50,12 +54,15 @@ export default class MessageService {
 		return messages.map(message => message.toJSON());
 	}
 
-	public async deleteMessage(data: Pick<APIMessage, 'id' | 'channelID'> & { authorID?: string }): Promise<void> {
-		if (!data.id) throw new APIError(HttpCode.NotFound, DeleteMessageError.NotFound);
-		const message = await getRepository(Message).findOneOrFail(data.id).catch(() => Promise.reject(new APIError(HttpCode.NotFound, DeleteMessageError.NotFound)));
-		if (message.channel.id !== data.channelID) throw new APIError(HttpCode.BadRequest, DeleteMessageError.InvalidChannel);
-		// If authorID is omitted, it means that the user has admin rights and does not need to provide their ID
-		if (data.authorID && message.author.id !== data.authorID) throw new APIError(HttpCode.BadRequest, DeleteMessageError.NotAuthor);
-		await getRepository(Message).delete(message);
+	public deleteMessage(data: Pick<APIMessage, 'id' | 'channelID'> & { authorID?: string }): Promise<void> {
+		return getConnection().transaction(async entityManager => {
+			if (!data.id) throw new APIError(HttpCode.NotFound, DeleteMessageError.NotFound);
+			const message = await entityManager.findOneOrFail(Message, data.id).catch(() => Promise.reject(new APIError(HttpCode.NotFound, DeleteMessageError.NotFound)));
+			if (message.channel.id !== data.channelID) throw new APIError(HttpCode.BadRequest, DeleteMessageError.InvalidChannel);
+			// If authorID is omitted, it means that the user has admin rights and does not need to provide their ID
+			if (data.authorID && message.author.id !== data.authorID) throw new APIError(HttpCode.BadRequest, DeleteMessageError.NotAuthor);
+			await entityManager.delete(Message, message.id);
+			await entityManager.update(Channel, message.channel.id, { lastUpdated: new Date() });
+		});
 	}
 }


### PR DESCRIPTION
Resolves #48 

This PR adds a `lastUpdated` timestamp property to all channels to check when they were last modified. This allows us to sort the channels by the order they should be displayed by a UI in the `/channels` endpoint.

The property is updated when the channel is first created, a message is sent to the channel, or a message is deleted from the channel.