### PR TITLE
feat: implement gateway heartbeating

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,9 @@
   ],
   "coveragePathIgnorePatterns": [
    "src/app.ts"
+  ],
+  "setupFilesAfterEnv": [
+    "<rootDir>/tests/util/setup.ts"
   ]
  },
  "dependencies": {

--- a/src/controllers/GatewayController.ts
+++ b/src/controllers/GatewayController.ts
@@ -3,20 +3,46 @@ import GatewayService from '../services/GatewayService';
 import WebSocket, { Server as WebSocketServer, Data } from 'ws';
 import { UserService } from '../services/UserService';
 import { verifyJWT } from '../util/auth';
-import { GatewayPacket, GatewayPacketType, HelloGatewayPacket, IdentifyGatewayPacket, GatewayError } from '../util/gateway';
+import { GatewayPacket, GatewayPacketType, HelloGatewayPacket, IdentifyGatewayPacket, GatewayError, PingGatewayPacket, PongGatewayPacket } from '../util/gateway';
 import { getConfig } from '../util/config';
+
+const HEARTBEAT_INTERVAL = 20_000;
+const HEARTBEAT_TOLERANCE = HEARTBEAT_INTERVAL * 3;
 
 @singleton()
 export default class GatewayController {
 	private readonly gatewayService: GatewayService;
 	private readonly userService: UserService;
 	private wss?: WebSocketServer;
-	public readonly authenticatedClients: Map<WebSocket, string>;
+	public readonly authenticatedClients: Map<WebSocket, { id: string; lastPong: number }>;
 
 	public constructor(@inject(GatewayService) gatewayService: GatewayService, @inject(UserService) userService: UserService) {
 		this.authenticatedClients = new Map();
 		this.gatewayService = gatewayService;
 		this.userService = userService;
+
+		setInterval(() => {
+			this.checkHeartbeats()
+				.catch(console.error);
+		}, HEARTBEAT_INTERVAL);
+	}
+
+	public async checkHeartbeats() {
+		const now = Date.now();
+		const payload: PingGatewayPacket = {
+			type: GatewayPacketType.Ping,
+			data: {
+				timestamp: Date.now()
+			}
+		};
+
+		/* sendMessage could fail if even one of the messages to the clients fails to send
+			We do not want this to happen in heartbeating, so we send the packet individually and then
+			catch errors so they do not cause the overall promise to reject */
+		return Promise.all([...this.authenticatedClients.entries()].map(([ws, { lastPong }]): Promise<any> => {
+			const lastAcceptablePong = lastPong + HEARTBEAT_TOLERANCE;
+			return now > lastAcceptablePong ? Promise.resolve(ws.close()) : this.gatewayService.send([ws], payload).catch(() => ws.close());
+		}));
 	}
 
 	public bindTo(wss: WebSocketServer) {
@@ -48,6 +74,8 @@ export default class GatewayController {
 		switch (packet.type) {
 			case GatewayPacketType.Identify:
 				return this.onAuthenticate(ws, packet as IdentifyGatewayPacket);
+			case GatewayPacketType.Pong:
+				return this.onPong(ws);
 			default:
 				throw new GatewayError(`Received invalid packet type ${packet.type}`);
 		}
@@ -58,7 +86,7 @@ export default class GatewayController {
 	}
 
 	public async sendMessage<T extends GatewayPacket>(to: string[], message: T) {
-		const recipients = [...this.authenticatedClients.entries()].filter(([,id]) => to.includes(id)).map(entry => entry[0]);
+		const recipients = [...this.authenticatedClients.entries()].filter(([,{ id }]) => to.includes(id)).map(entry => entry[0]);
 		await this.gatewayService.send(recipients, message);
 	}
 
@@ -68,9 +96,15 @@ export default class GatewayController {
 		const { id } = await verifyJWT(token).catch(() => Promise.reject(new GatewayError('Invalid token')));
 		const user = await this.userService.findOne({ id });
 		if (!user) throw new GatewayError('User not found');
-		this.authenticatedClients.set(ws, user.id);
+		this.authenticatedClients.set(ws, { id: user.id, lastPong: new Date().getTime() });
 		await this.gatewayService.send([ws], {
 			type: GatewayPacketType.Hello
 		} as HelloGatewayPacket);
+	}
+
+	public onPong(ws: WebSocket) {
+		const userConfig = this.authenticatedClients.get(ws);
+		if (!userConfig) throw new GatewayError('Not authenticated');
+		userConfig.lastPong = Date.now();
 	}
 }

--- a/src/util/gateway/index.ts
+++ b/src/util/gateway/index.ts
@@ -6,11 +6,27 @@ export enum GatewayPacketType {
 	Identify = 'IDENTIFY',
 	Hello = 'HELLO',
 	MessageCreate = 'MESSAGE_CREATE',
-	MessageDelete = 'MESSAGE_DELETE'
+	MessageDelete = 'MESSAGE_DELETE',
+	Ping = 'PING',
+	Pong = 'PONG'
 }
 
 export interface GatewayPacket {
 	type: GatewayPacketType;
+}
+
+export interface PingGatewayPacket {
+	type: GatewayPacketType.Ping;
+	data: {
+		timestamp: number;
+	};
+}
+
+export interface PongGatewayPacket {
+	type: GatewayPacketType.Pong;
+	data: {
+		timestamp: number;
+	};
 }
 
 export interface IdentifyGatewayPacket extends GatewayPacket {

--- a/tests/integration/app.test.ts
+++ b/tests/integration/app.test.ts
@@ -1,5 +1,4 @@
 import { createApp } from '../../src';
-import '../util/dbTeardown';
 
 describe('app', () => {
 	test('App is created with valid properties', async () => {

--- a/tests/integration/controllers/eventController.test.ts
+++ b/tests/integration/controllers/eventController.test.ts
@@ -2,7 +2,6 @@ import { createApp } from '../../../src';
 import { mock, instance, when, anything, verify, objectContaining, reset } from 'ts-mockito';
 import { container } from 'tsyringe';
 import supertest from 'supertest';
-import '../../util/dbTeardown';
 import users from '../../fixtures/users';
 import { APIError, HttpCode } from '../../../src/util/errors';
 import * as middleware from '../../../src/routes/middleware/getUser';

--- a/tests/integration/controllers/gatewayController.test.ts
+++ b/tests/integration/controllers/gatewayController.test.ts
@@ -21,6 +21,10 @@ beforeAll(() => {
 	gatewayController = createGateway(wss);
 });
 
+afterAll(() => {
+	gatewayController.stopHeartbeats();
+});
+
 function createWebSocket(): Promise<MockWebSocket> {
 	return new Promise((resolve, reject) => {
 		const ws = new MockWebSocket(wss);
@@ -69,7 +73,7 @@ describe('GatewayController', () => {
 
 		test('broadcast', async () => {
 			// Authenticate the first socket
-			gatewayController.authenticatedClients.set(sockets[0].mirror, '');
+			gatewayController.authenticatedClients.set(sockets[0].mirror, { id: '', lastPong: Date.now() });
 
 			const payload = { time: Date.now() };
 			const stringPayload = JSON.stringify(payload);
@@ -80,7 +84,7 @@ describe('GatewayController', () => {
 			expect(sockets[1].allMessages.length).toEqual(0);
 
 			// Authenticate the second socket
-			gatewayController.authenticatedClients.set(sockets[1].mirror, '');
+			gatewayController.authenticatedClients.set(sockets[1].mirror, { id: '', lastPong: Date.now() });
 			await gatewayController.broadcast(payload as any);
 			await expect(sockets[0].nextMessage).resolves.toEqual(stringPayload);
 			await expect(sockets[1].nextMessage).resolves.toEqual(stringPayload);
@@ -88,8 +92,8 @@ describe('GatewayController', () => {
 
 		test('sendTo', async () => {
 			// Authenticate the first socket
-			gatewayController.authenticatedClients.set(sockets[0].mirror, 'banana');
-			gatewayController.authenticatedClients.set(sockets[1].mirror, 'apple');
+			gatewayController.authenticatedClients.set(sockets[0].mirror, { id: 'banana', lastPong: Date.now() });
+			gatewayController.authenticatedClients.set(sockets[1].mirror, { id: 'apple', lastPong: Date.now() });
 
 			const payload = { time: Date.now() };
 			const stringPayload = JSON.stringify(payload);

--- a/tests/integration/controllers/messageController.test.ts
+++ b/tests/integration/controllers/messageController.test.ts
@@ -2,7 +2,6 @@ import { createApp } from '../../../src';
 import { mock, instance, when, verify, objectContaining, reset, anything, resetCalls } from 'ts-mockito';
 import { container } from 'tsyringe';
 import supertest from 'supertest';
-import '../../util/dbTeardown';
 import users from '../../fixtures/users';
 import { APIError, HttpCode } from '../../../src/util/errors';
 import * as getUserMiddleware from '../../../src/routes/middleware/getUser';

--- a/tests/integration/controllers/userController.test.ts
+++ b/tests/integration/controllers/userController.test.ts
@@ -5,7 +5,6 @@ import { mock, instance, when, anything, verify, objectContaining, reset } from 
 import { container } from 'tsyringe';
 import supertest from 'supertest';
 import * as authUtils from '../../../src/util/auth';
-import '../../util/dbTeardown';
 import emailConfirmations from '../../fixtures/emailConfirmations';
 import users from '../../fixtures/users';
 import { APIError, HttpCode } from '../../../src/util/errors';

--- a/tests/unit/services/eventService.test.ts
+++ b/tests/unit/services/eventService.test.ts
@@ -5,7 +5,6 @@ import { createDBConnection } from '../../../src';
 import { Event, APIEvent } from '../../../src/entities/Event';
 import events from '../../fixtures/events';
 import { getConnection, getRepository } from 'typeorm';
-import '../../util/dbTeardown';
 import { HttpCode } from '../../../src/util/errors';
 
 

--- a/tests/unit/services/messageService.test.ts
+++ b/tests/unit/services/messageService.test.ts
@@ -2,7 +2,6 @@ import 'reflect-metadata';
 
 import { createDBConnection } from '../../../src';
 import { getConnection, getRepository } from 'typeorm';
-import '../../util/dbTeardown';
 import MessageService from '../../../src/services/MessageService';
 import users from '../../fixtures/users';
 import events from '../../fixtures/events';

--- a/tests/unit/services/userService.test.ts
+++ b/tests/unit/services/userService.test.ts
@@ -1,7 +1,6 @@
 import { UserService } from '../../../src/services/UserService';
 import { createDBConnection } from '../../../src';
 import { AccountStatus, AccountType, User } from '../../../src/entities/User';
-import '../../util/dbTeardown';
 import users from '../../fixtures/users';
 import * as passwordUtils from '../../../src/util/password';
 import { getConnection, getRepository } from 'typeorm';

--- a/tests/util/dbTeardown.ts
+++ b/tests/util/dbTeardown.ts
@@ -1,6 +1,0 @@
-import { getConnection } from 'typeorm';
-
-afterAll(async () => {
-	await getConnection().dropDatabase();
-	await getConnection().close();
-});

--- a/tests/util/setup.ts
+++ b/tests/util/setup.ts
@@ -1,0 +1,16 @@
+import { getConnection } from 'typeorm';
+import { container } from 'tsyringe';
+import GatewayController from '../../src/controllers/GatewayController';
+
+afterAll(async () => {
+	try {
+		const connection = getConnection();
+		await connection.dropDatabase();
+		await connection.close();
+	} catch (e) { }
+
+	try {
+		const gateway = container.resolve(GatewayController);
+		gateway.stopHeartbeats();
+	} catch (e) { }
+});


### PR DESCRIPTION
Resolves #49 

This implements gateway heartbeating to ensure that the WebSocket clients are still connected. It does this by sending a `PING` packet every 20 seconds. Clients should respond with a `PONG` packet whenever a `PING` packet is sent.

Whenever the gateway sends heartbeats to the clients, it also checks that clients have been replying in time. If a client has not replied in over 60 seconds, then the client is disconnected.

Tests are also slightly improved, using a common setup script that includes teardown logic for all tests - this no longer needs to be imported manually.