### PR TITLE
fix: DM channel creation and getChannelsForUser

### DIFF
--- a/src/entities/Channel.ts
+++ b/src/entities/Channel.ts
@@ -18,7 +18,7 @@ export interface APIEventChannel extends APIChannel {
 export interface APIDMChannel extends APIChannel {
 	users: string[];
 	type: 'dm';
-	video?: APIVideoIntegration & { accessToken?: string };
+	video?: APIVideoIntegration;
 }
 
 @Entity()

--- a/src/services/ChannelService.ts
+++ b/src/services/ChannelService.ts
@@ -67,7 +67,7 @@ export default class ChannelService {
 			const recipients = await entityManager.findByIds(User, recipientIDs);
 
 			// Ensure that all the recipients are verified
-			if (recipients.some(recipient => recipient.accountStatus !== AccountStatus.Verified)) {
+			if (recipients.some(recipient => recipient.accountStatus !== AccountStatus.Verified) || recipients.length !== recipientIDs.length) {
 				throw new APIError(400, CreateDMChannelError.UsersNotVerified);
 			}
 


### PR DESCRIPTION
## About

### DMChannels fix

When creating a DM channel, it was possible to provide an invalid user ID (e.g. valid UUID but user doesn't exist), and the API would make a channel with only one user in it.

This fixes that, and makes sure that both users exist before creating the DM channel.

### getChannels fix

Wasn't returning video information for applicable DM channels, this has now been added.
