### PR TITLE
refactor: switch to time-based pagination for getMessages

### DIFF
--- a/src/controllers/MessageController.ts
+++ b/src/controllers/MessageController.ts
@@ -48,11 +48,11 @@ export class MessageController {
 		}
 	}
 
-	public async getMessages(req: Request & { params: { channelID: string; page: number } }, res: ChannelResponse, next: NextFunction): Promise<void> {
+	public async getMessages(req: Request & { params: { channelID: string }; query: { before: string } }, res: ChannelResponse, next: NextFunction): Promise<void> {
 		try {
 			const messages = await this.messageService.getMessages({
 				channel: res.locals.channel,
-				page: Number(req.query.page),
+				before: new Date(req.query.before),
 				count: 50
 			});
 			res.json({ messages });

--- a/tests/unit/services/messageService.test.ts
+++ b/tests/unit/services/messageService.test.ts
@@ -82,8 +82,9 @@ describe('MessageService', () => {
 		});
 
 		test('Pagination works as expected', async () => {
+			const originalTime = timeCounter + baseMessages.length;
 			for (let i = 0; i < 5; i++) {
-				const page = await messageService.getMessages({ channel, count: 2, page: i });
+				const page = await messageService.getMessages({ channel, count: 2, before: new Date((originalTime - (i * 2)) + 1) });
 				expect(page).toEqual(baseMessages.slice(i * 2, (i + 1) * 2).map(m => m.toJSON()));
 			}
 		});


### PR DESCRIPTION
Resolves #83.

Uses a time-based pagination system for getMessages. Instead of passing a page number, you now pass a "before" date ISO string, and the first 50 messages before the given time (not including it!) are returned.
