### PR TITLE
fix: show file size limit in error messages

### DIFF
--- a/src/routes/middleware/uploadImg.ts
+++ b/src/routes/middleware/uploadImg.ts
@@ -14,7 +14,8 @@ export default function uploadImg(fileName: string) {
 	return (req: Request, res: Response, next: NextFunction) => {
 		upload.single(fileName)(req, res, (err?: any) => {
 			if (err instanceof multer.MulterError) {
-				return next(new APIError(HttpCode.BadRequest, err.message));
+				const message = err.code === 'LIMIT_FILE_SIZE' ? 'File too large (1MB limit)' : err.message;
+				return next(new APIError(HttpCode.BadRequest, message));
 			} else if (err) {
 				return next(err);
 			}


### PR DESCRIPTION
Resolves #118 