### PR TITLE
refactor: allow for enabling/disabling ratelimiting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 PORT=8060
 LOG_ERRORS=true
 HOST=http://localhost:3000
+RATE_LIMITING=true
 
 DB_HOST=localhost
 DB_PORT=5432

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ test: export DISCORD_OAUTH2_SECRET=abc
 test: export DISCORD_GUILD_ID=abc
 test: export DISCORD_BOT_TOKEN=abc
 test: export DISCORD_VERIFIED_ROLE_ID=abc
+test: export RATE_LIMITING=false
 test:
 	docker-compose -f tests/docker-compose.yml up -d db
 	@node scripts/waitForPort $(DB_PORT)

--- a/src/routes/ChannelRoutes.ts
+++ b/src/routes/ChannelRoutes.ts
@@ -5,7 +5,7 @@ import { MessageController } from '../controllers/MessageController';
 import getChannel from './middleware/getChannel';
 import { UserController } from '../controllers/UserController';
 import { TokenType } from '../util/auth';
-import { sendMessageRateLimit } from '../util/ratelimits';
+import { getRatelimiter, RateLimiter } from '../util/ratelimits';
 
 @injectable()
 export class ChannelRoutes {
@@ -19,7 +19,7 @@ export class ChannelRoutes {
 
 	public routes(router: Router): void {
 		router.get('/channels', getUser(TokenType.Auth), isVerified, this.userController.getChannels.bind(this.userController));
-		router.post('/channels/:channelID/messages', sendMessageRateLimit, getUser(TokenType.Auth), isVerified, getChannel, this.messageController.createMessage.bind(this.messageController));
+		router.post('/channels/:channelID/messages', getRatelimiter(RateLimiter.SendMessage), getUser(TokenType.Auth), isVerified, getChannel, this.messageController.createMessage.bind(this.messageController));
 		router.get('/channels/:channelID/messages', getUser(TokenType.Auth), isVerified, getChannel, this.messageController.getMessages.bind(this.messageController));
 		router.get('/channels/:channelID/messages/:messageID', getUser(TokenType.Auth), isVerified, this.messageController.getMessage.bind(this.messageController));
 		router.delete('/channels/:channelID/messages/:messageID', getUser(TokenType.Auth), isVerified, getChannel, this.messageController.deleteMessage.bind(this.messageController));

--- a/src/routes/UserRoutes.ts
+++ b/src/routes/UserRoutes.ts
@@ -4,7 +4,7 @@ import { inject, injectable } from 'tsyringe';
 import { getUser, isVerified, uploadImg } from './middleware';
 import { TokenType } from '../util/auth';
 import { DiscordController } from '../controllers/DiscordController';
-import { registerRateLimit, discordRateLimit, reportRateLimit, resendVerificationRateLimit, forgotPasswordRateLimit } from '../util/ratelimits';
+import { getRatelimiter, RateLimiter } from '../util/ratelimits';
 
 @injectable()
 export class UserRoutes {
@@ -17,15 +17,15 @@ export class UserRoutes {
 	}
 
 	public routes(router: Router): void {
-		router.post('/register', registerRateLimit, this.userController.registerUser.bind(this.userController));
+		router.post('/register', getRatelimiter(RateLimiter.Register), this.userController.registerUser.bind(this.userController));
 
 		router.get('/verify', getUser(TokenType.EmailVerify), this.userController.verifyUserEmail.bind(this.userController));
 
-		router.post('/resendVerificationEmail', resendVerificationRateLimit, this.userController.resendVerificationEmail.bind(this.userController));
+		router.post('/resendVerificationEmail', getRatelimiter(RateLimiter.ResendVerificationEmail), this.userController.resendVerificationEmail.bind(this.userController));
 
 		router.post('/authenticate', this.userController.authenticate.bind(this.userController));
 
-		router.post('/forgot_password', forgotPasswordRateLimit, this.userController.forgotPassword.bind(this.userController));
+		router.post('/forgot_password', getRatelimiter(RateLimiter.ForgotPassword), this.userController.forgotPassword.bind(this.userController));
 
 		router.post('/reset_password', getUser(TokenType.PasswordReset), this.userController.resetPassword.bind(this.userController));
 
@@ -39,13 +39,13 @@ export class UserRoutes {
 
 		router.delete('/users/@me/notes/:id', getUser(TokenType.Auth), isVerified, this.userController.deleteNote.bind(this.userController));
 
-		router.post('/users/:id/report', reportRateLimit, getUser(TokenType.Auth), isVerified, this.userController.reportUser.bind(this.userController));
+		router.post('/users/:id/report', getRatelimiter(RateLimiter.Report), getUser(TokenType.Auth), isVerified, this.userController.reportUser.bind(this.userController));
 
 		router.put('/users/@me/profile', getUser(TokenType.Auth), isVerified, uploadImg('avatar'), this.userController.putUserProfile.bind(this.userController));
 
 		router.get('/users/@me/discord/authorize', getUser(TokenType.Auth), isVerified, this.discordController.getOAuth2AuthorizeURL.bind(this.discordController));
 
-		router.post('/users/@me/discord/link', discordRateLimit, getUser(TokenType.Auth), this.discordController.linkAccount.bind(this.discordController));
+		router.post('/users/@me/discord/link', getRatelimiter(RateLimiter.Discord), getUser(TokenType.Auth), this.discordController.linkAccount.bind(this.discordController));
 
 		router.post('/users/:recipientID/channel', getUser(TokenType.Auth), isVerified, this.userController.createDMChannel.bind(this.userController));
 	}

--- a/src/util/config/index.ts
+++ b/src/util/config/index.ts
@@ -10,6 +10,7 @@ export interface EnvConfig {
 	logErrors: boolean;
 	host: string;
 	jwtSecret: string;
+	rateLimiting: boolean;
 	db: {
 		host: string;
 		port: number;
@@ -45,6 +46,7 @@ export function load(source: Record<string, string | undefined> = process.env): 
 		logErrors: intoBoolean(getEnv(source, 'LOG_ERRORS')),
 		host: getEnv(source, 'HOST'),
 		jwtSecret: getEnv(source, 'JWT_SECRET'),
+		rateLimiting: intoBoolean(getEnv(source, 'RATE_LIMITING')),
 		db: {
 			host: getEnv(source, 'DB_HOST'),
 			port: intoNumber(getEnv(source, 'DB_PORT')),

--- a/tests/unit/util/config/config.test.ts
+++ b/tests/unit/util/config/config.test.ts
@@ -26,12 +26,14 @@ const fixture1: [Record<string, string>, EnvConfig] = [
 		DISCORD_OAUTH2_SECRET: 'c',
 		DISCORD_GUILD_ID: 'd',
 		DISCORD_BOT_TOKEN: 'e',
-		DISCORD_VERIFIED_ROLE_ID: 'f'
+		DISCORD_VERIFIED_ROLE_ID: 'f',
+		RATE_LIMITING: 'true'
 	},
 	{
 		port: 8000,
 		logErrors: true,
 		host: 'https://kb.unicsmcr.com',
+		rateLimiting: true,
 		db: {
 			host: 'localhost',
 			username: 'root',
@@ -88,11 +90,13 @@ const fixture2: [Record<string, string>, EnvConfig] = [
 		DISCORD_OAUTH2_SECRET: 'def',
 		DISCORD_GUILD_ID: '456',
 		DISCORD_BOT_TOKEN: 'ghi',
-		DISCORD_VERIFIED_ROLE_ID: '789'
+		DISCORD_VERIFIED_ROLE_ID: '789',
+		RATE_LIMITING: 'false'
 	},
 	{
 		port: 25565,
 		logErrors: false,
+		rateLimiting: false,
 		host: 'http://localhost:3000',
 		db: {
 			host: 'db',


### PR DESCRIPTION
Resolves #124 

Allows the rate-limiting functionality to be enabled or disabled with the `RATE_LIMITING` boolean env variable. In tests, this is disabled.