### PR TITLE
feat: mock twilio service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,7 @@ TWILIO_AUTH_TOKEN=xxxxx
 TWILIO_API_KEY=SKxxxxx
 # The API Key's Secret
 TWILIO_SECRET=randomstringhere123
+MOCK_TWILIO_SERVICE=false
 
 EMAIL_CONFIG=smtps://user@unicsmcr.com:password@emailhost.com/?pool=true
 EMAIL_FROM_EMAIL=UniCS KB <youremail@unicsmcr.com>

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ test: export TWILIO_ACCOUNT_SID=AC123
 test: export TWILIO_AUTH_TOKEN=token123
 test: export TWILIO_API_KEY=SKxxxx
 test: export TWILIO_SECRET=randomstringggg123
+test: export MOCK_TWILIO_SERVICE=true
 test: export DISCORD_CLIENT_ID=abc
 test: export DISCORD_CLIENT_SECRET=abc
 test: export DISCORD_OAUTH2_SECRET=abc

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,8 @@ import GatewayController from './controllers/GatewayController';
 import { EventRoutes } from './routes/EventRoutes';
 import { ChannelRoutes } from './routes/ChannelRoutes';
 import { logger } from './util/logger';
+import { TwilioService } from './services/twilio/TwilioService';
+import { MockTwilioService } from './services/twilio/MockTwilioService';
 
 export function createExpress() {
 	const app = express();
@@ -39,6 +41,10 @@ export function createExpress() {
 			useClass: getConfig().email.mock ? MockEmailService as any : EmailService
 		});
 	}
+
+	container.register<TwilioService>(TwilioService, {
+		useClass: getConfig().twilio.mock ? MockTwilioService as any : TwilioService
+	});
 
 	container.resolve(UserRoutes).routes(router);
 	container.resolve(EventRoutes).routes(router);

--- a/src/services/ChannelService.ts
+++ b/src/services/ChannelService.ts
@@ -3,7 +3,7 @@ import { getRepository, FindOneOptions, FindConditions, getConnection } from 'ty
 import { Channel, DMChannel, APIDMChannel, APIChannel, EventChannel } from '../entities/Channel';
 import { User, AccountStatus } from '../entities/User';
 import { APIError } from '../util/errors';
-import { TwilioService } from './TwilioService';
+import { TwilioService } from './twilio/TwilioService';
 import { VideoIntegration } from '../entities/VideoIntegration';
 import { VideoUser } from '../entities/VideoUser';
 import { ROOM_TIME_LIMIT_MS } from '../util/config/video';

--- a/src/services/twilio/MockTwilioService.ts
+++ b/src/services/twilio/MockTwilioService.ts
@@ -1,0 +1,26 @@
+import { singleton } from 'tsyringe';
+import { ITwilioService } from './TwilioService';
+
+interface GenerateAccessTokenOptions {
+	userId: string;
+	roomId: string;
+}
+
+@singleton()
+export class MockTwilioService implements ITwilioService {
+	public teardown() {
+		return undefined;
+	}
+
+	public async createRoom(roomId: string): Promise<string> {
+		return Promise.resolve(roomId);
+	}
+
+	public async completeRoom(): Promise<void> {
+		return Promise.resolve(undefined);
+	}
+
+	public generateAccessToken(options: GenerateAccessTokenOptions): string {
+		return [options.roomId, options.userId, String(Date.now())].join('');
+	}
+}

--- a/src/services/twilio/TwilioService.ts
+++ b/src/services/twilio/TwilioService.ts
@@ -9,8 +9,15 @@ interface GenerateAccessTokenOptions {
 	roomId: string;
 }
 
+export interface ITwilioService {
+	teardown(): void;
+	createRoom(roomId: string): Promise<string>;
+	completeRoom(roomId: string): Promise<void>;
+	generateAccessToken(options: GenerateAccessTokenOptions): string;
+}
+
 @singleton()
-export class TwilioService {
+export class TwilioService implements ITwilioService {
 	private readonly twilioClient: Twilio;
 	private timeouts: NodeJS.Timeout[];
 

--- a/src/services/twilio/TwilioService.ts
+++ b/src/services/twilio/TwilioService.ts
@@ -1,8 +1,8 @@
 import { singleton } from 'tsyringe';
 import buildClient, { Twilio, jwt } from 'twilio';
-import { getConfig } from '../util/config';
-import { logger } from '../util/logger';
-import { ROOM_TIME_LIMIT_TTL_SECS, ROOM_TIME_LIMIT_MS } from '../util/config/video';
+import { getConfig } from '../../util/config';
+import { logger } from '../../util/logger';
+import { ROOM_TIME_LIMIT_TTL_SECS, ROOM_TIME_LIMIT_MS } from '../../util/config/video';
 
 interface GenerateAccessTokenOptions {
 	userId: string;

--- a/src/util/config/index.ts
+++ b/src/util/config/index.ts
@@ -28,6 +28,7 @@ export interface EnvConfig {
 		token: string;
 		secret: string;
 		apiKey: string;
+		mock: boolean;
 	};
 	discord: {
 		oauth2Secret: string;
@@ -62,7 +63,8 @@ export function load(source: Record<string, string | undefined> = process.env): 
 			accountSid: getEnv(source, 'TWILIO_ACCOUNT_SID'),
 			token: getEnv(source, 'TWILIO_AUTH_TOKEN'),
 			apiKey: getEnv(source, 'TWILIO_API_KEY'),
-			secret: getEnv(source, 'TWILIO_SECRET')
+			secret: getEnv(source, 'TWILIO_SECRET'),
+			mock: intoBoolean(getEnv(source, 'MOCK_TWILIO_SERVICE'))
 		},
 		discord: {
 			clientID: getEnv(source, 'DISCORD_CLIENT_ID'),

--- a/tests/unit/util/config/config.test.ts
+++ b/tests/unit/util/config/config.test.ts
@@ -21,6 +21,7 @@ const fixture1: [Record<string, string>, EnvConfig] = [
 		TWILIO_AUTH_TOKEN: 'TESTTOKEN',
 		TWILIO_API_KEY: 'SK123',
 		TWILIO_SECRET: 'asecret123',
+		MOCK_TWILIO_SERVICE: 'false',
 		DISCORD_CLIENT_ID: 'a',
 		DISCORD_CLIENT_SECRET: 'b',
 		DISCORD_OAUTH2_SECRET: 'c',
@@ -49,7 +50,8 @@ const fixture1: [Record<string, string>, EnvConfig] = [
 			accountSid: 'ACX123',
 			token: 'TESTTOKEN',
 			apiKey: 'SK123',
-			secret: 'asecret123'
+			secret: 'asecret123',
+			mock: false
 		},
 		discord: {
 			clientID: 'a',
@@ -83,6 +85,7 @@ const fixture2: [Record<string, string>, EnvConfig] = [
 		TWILIO_AUTH_TOKEN: 'token123',
 		TWILIO_API_KEY: 'SKabc123',
 		TWILIO_SECRET: 'secretabc123',
+		MOCK_TWILIO_SERVICE: 'true',
 		DISCORD_CLIENT_ID: 'abc',
 		DISCORD_CLIENT_SECRET: '123',
 		DISCORD_OAUTH2_SECRET: 'def',
@@ -111,7 +114,8 @@ const fixture2: [Record<string, string>, EnvConfig] = [
 			accountSid: 'ACX5674567234',
 			token: 'token123',
 			apiKey: 'SKabc123',
-			secret: 'secretabc123'
+			secret: 'secretabc123',
+			mock: true
 		},
 		discord: {
 			clientID: 'abc',

--- a/tests/util/setup.ts
+++ b/tests/util/setup.ts
@@ -1,7 +1,7 @@
 import { getConnection } from 'typeorm';
 import { container } from 'tsyringe';
 import GatewayController from '../../src/controllers/GatewayController';
-import { TwilioService } from '../../src/services/TwilioService';
+import { TwilioService } from '../../src/services/twilio/TwilioService';
 
 afterAll(async () => {
 	try {


### PR DESCRIPTION
Resolves #92 

This creates a mock TwilioService, which can be used locally without any Twilio API keys. To enable it, set `MOCK_TWILIO_SERVICE=true` in your .env file; obviously, video chat will not work if you enable this.