### PR TITLE
feat: add NODE_ENV to config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@ PORT=8060
 LOG_ERRORS=true
 HOST=http://localhost:3000
 RATE_LIMITING=true
+NODE_ENV=development
 
 DB_HOST=localhost
 DB_PORT=5432

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ test: export DISCORD_GUILD_ID=abc
 test: export DISCORD_BOT_TOKEN=abc
 test: export DISCORD_VERIFIED_ROLE_ID=abc
 test: export RATE_LIMITING=false
+test: export NODE_ENV=development
 test: export EVENT_USERS=
 test:
 	docker-compose -f tests/docker-compose.yml up -d db

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,14 +6,14 @@ import { logger } from './util/logger';
 
 createApp()
 	.then(app => {
-		const port = getConfig().port;
+		const { port, env } = getConfig();
 		const server = createServer(app);
 
 		const wss = new WebSocketServer({ server, path: '/api/v1/gateway' });
 		createGateway(wss);
 
 		server.listen(port, () => {
-			logger.info(`Listening on port ${port}`);
+			logger.info(`Listening on port ${port}. Running in ${env} environment.`);
 		});
 	})
 	.catch(err => logger.error(err));

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import express, { Router, Response, Request, NextFunction } from 'express';
 import cors from 'cors';
 
 import { createConnection } from 'typeorm';
-import { getConfig } from './util/config';
+import { getConfig, Environment } from './util/config';
 import { UserRoutes } from './routes/UserRoutes';
 import { container } from 'tsyringe';
 import EmailService from './services/email/EmailService';
@@ -77,7 +77,7 @@ export async function createDBConnection() {
 		entities: [
 			`${__dirname}/entities/**/*{.js,.ts}`
 		],
-		synchronize: true,
+		synchronize: getConfig().env === Environment.Dev,
 		logging: false
 	});
 }

--- a/src/util/config/index.ts
+++ b/src/util/config/index.ts
@@ -1,7 +1,7 @@
 import { getEnv, intoNumber, intoBoolean, getEnvOrDefault } from './util';
 
 export enum Environment {
-	Dev = 'dev',
+	Dev = 'development',
 	Production = 'production'
 }
 
@@ -12,6 +12,7 @@ export interface EnvConfig {
 	jwtSecret: string;
 	rateLimiting: boolean;
 	eventUsers: string[];
+	env: Environment;
 	db: {
 		host: string;
 		port: number;
@@ -43,6 +44,11 @@ export interface EnvConfig {
 }
 
 export function load(source: Record<string, string | undefined> = process.env): EnvConfig {
+	const env = getEnv(source, 'NODE_ENV') as Environment;
+	if (![Environment.Dev, Environment.Production].includes(env)) {
+		throw new Error(`Invalid NODE_ENV variable, must be 'development' or 'production'`);
+	}
+
 	return {
 		port: intoNumber(getEnv(source, 'PORT')),
 		logErrors: intoBoolean(getEnv(source, 'LOG_ERRORS')),
@@ -51,6 +57,7 @@ export function load(source: Record<string, string | undefined> = process.env): 
 		rateLimiting: intoBoolean(getEnv(source, 'RATE_LIMITING')),
 		eventUsers: getEnvOrDefault(source, 'EVENT_USERS', '').split(',').map(s => s.trim())
 			.filter(Boolean),
+		env,
 		db: {
 			host: getEnv(source, 'DB_HOST'),
 			port: intoNumber(getEnv(source, 'DB_PORT')),

--- a/tests/unit/util/config/config.test.ts
+++ b/tests/unit/util/config/config.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-dynamic-delete */
-import { load, EnvConfig, getConfig } from '../../../../src/util/config';
+import { load, EnvConfig, getConfig, Environment } from '../../../../src/util/config';
 
 // Valid fixture
 const fixture1: [Record<string, string>, EnvConfig] = [
@@ -29,13 +29,15 @@ const fixture1: [Record<string, string>, EnvConfig] = [
 		DISCORD_BOT_TOKEN: 'e',
 		DISCORD_VERIFIED_ROLE_ID: 'f',
 		RATE_LIMITING: 'true',
-		EVENT_USERS: 'a,b'
+		EVENT_USERS: 'a,b',
+		NODE_ENV: 'development'
 	},
 	{
 		port: 8000,
 		logErrors: true,
 		host: 'https://kb.unicsmcr.com',
 		rateLimiting: true,
+		env: Environment.Dev,
 		db: {
 			host: 'localhost',
 			username: 'root',
@@ -97,7 +99,8 @@ const fixture2: [Record<string, string>, EnvConfig] = [
 		DISCORD_BOT_TOKEN: 'ghi',
 		DISCORD_VERIFIED_ROLE_ID: '789',
 		RATE_LIMITING: 'false',
-		EVENT_USERS: '1, 2,3'
+		EVENT_USERS: '1, 2,3',
+		NODE_ENV: 'production'
 	},
 	{
 		port: 25565,
@@ -105,6 +108,7 @@ const fixture2: [Record<string, string>, EnvConfig] = [
 		rateLimiting: false,
 		host: 'http://localhost:3000',
 		eventUsers: ['1', '2', '3'],
+		env: Environment.Production,
 		db: {
 			host: 'db',
 			username: 'unics_social',


### PR DESCRIPTION
In a production environment, the database should not be synchronised as this can lead to accidental data loss. In case of schema changes, migrations should be used instead.

This PR adds `NODE_ENV` to the .env config. When in `development`, the database is still synchronised. When in `production`, the database is not synchronised.
